### PR TITLE
feat: implement ingestion, IR, and knowledge graph cores

### DIFF
--- a/src/Medical_KG/ingestion/__init__.py
+++ b/src/Medical_KG/ingestion/__init__.py
@@ -3,10 +3,13 @@
 from .http_client import AsyncHttpClient
 from .ledger import IngestionLedger
 from .models import Document, IngestionResult
+from .registry import available_sources, get_adapter
 
 __all__ = [
     "AsyncHttpClient",
     "IngestionLedger",
     "Document",
     "IngestionResult",
+    "available_sources",
+    "get_adapter",
 ]

--- a/src/Medical_KG/ingestion/adapters/clinical.py
+++ b/src/Medical_KG/ingestion/adapters/clinical.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+import re
+import xml.etree.ElementTree as ET
+from collections.abc import AsyncIterator, Iterable
+from typing import Any
+
+from Medical_KG.ingestion.adapters.base import AdapterContext
+from Medical_KG.ingestion.adapters.http import HttpAdapter
+from Medical_KG.ingestion.http_client import AsyncHttpClient
+from Medical_KG.ingestion.models import Document
+from Medical_KG.ingestion.utils import canonical_json, normalize_text
+
+_CT_NCT_RE = re.compile(r"^NCT\d{8}$")
+_GTIN14_RE = re.compile(r"^\d{14}$")
+
+
+class ClinicalTrialsGovAdapter(HttpAdapter):
+    """Adapter for ClinicalTrials.gov v2 API."""
+
+    source = "clinicaltrials"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        api_base: str = "https://clinicaltrials.gov/api/v2",
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self.api_base = api_base.rstrip("/")
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, *_, **__) -> AsyncIterator[Any]:  # pragma: no cover - wrapper around bootstrap
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        # Minimal API loop for live use
+        page_token: str | None = None
+        params: dict[str, Any] = {"pageSize": 100}
+        while True:
+            if page_token:
+                params["pageToken"] = page_token
+            payload = await self.fetch_json(f"{self.api_base}/studies", params=params)
+            for study in payload.get("studies", []):
+                yield study
+            page_token = payload.get("nextPageToken")
+            if not page_token:
+                break
+
+    def parse(self, raw: Any) -> Document:
+        protocol = raw.get("protocolSection", {})
+        identification = protocol.get("identificationModule", {})
+        nct_id = identification.get("nctId", "")
+        title = normalize_text(identification.get("briefTitle", ""))
+        status = protocol.get("statusModule", {}).get("overallStatus")
+        summary = normalize_text(protocol.get("descriptionModule", {}).get("briefSummary", ""))
+        version = raw.get("derivedSection", {}).get("miscInfoModule", {}).get("version", "unknown")
+        payload = {
+            "nct_id": nct_id,
+            "title": title,
+            "status": status,
+            "phase": ", ".join(protocol.get("designModule", {}).get("phases", []) or []),
+            "study_type": protocol.get("designModule", {}).get("studyType"),
+            "arms": protocol.get("armsInterventionsModule", {}).get("arms", []),
+            "eligibility": protocol.get("eligibilityModule", {}).get("eligibilityCriteria"),
+            "outcomes": protocol.get("outcomesModule", {}).get("primaryOutcomes", []),
+            "version": version,
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=nct_id, version=version, content=content)
+        metadata = {
+            "title": title,
+            "status": status,
+            "record_version": version,
+        }
+        return Document(
+            doc_id=doc_id,
+            source=self.source,
+            content=summary or title,
+            metadata=metadata,
+            raw=payload,
+        )
+
+    def validate(self, document: Document) -> None:
+        nct_id = document.raw.get("nct_id")  # type: ignore[assignment]
+        if not isinstance(nct_id, str) or not _CT_NCT_RE.match(nct_id):
+            raise ValueError(f"Invalid NCT ID: {nct_id}")
+        outcomes = document.raw.get("outcomes", [])  # type: ignore[assignment]
+        if outcomes and not isinstance(outcomes, list):
+            raise ValueError("Outcomes must be a list")
+
+
+class OpenFdaAdapter(HttpAdapter):
+    """Adapter for openFDA resources."""
+
+    source = "openfda"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        api_key: str | None = None,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self.api_key = api_key
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, resource: str, *, search: str | None = None, limit: int = 100) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        params: dict[str, Any] = {"limit": limit}
+        if search:
+            params["search"] = search
+        if self.api_key:
+            params["api_key"] = self.api_key
+        payload = await self.fetch_json(f"https://api.fda.gov/{resource}.json", params=params)
+        for record in payload.get("results", []):
+            yield record
+
+    def parse(self, raw: Any) -> Document:
+        identifier = raw.get("safetyreportid") or raw.get("udi_di") or raw.get("setid") or raw.get("id")
+        if not identifier:
+            raise ValueError("Record missing identifier")
+        payload = dict(raw)
+        content = canonical_json(payload)
+        version = raw.get("receivedate") or raw.get("version_number") or raw.get("last_updated", "unknown")
+        doc_id = self.build_doc_id(identifier=str(identifier), version=str(version), content=content)
+        return Document(
+            doc_id=doc_id,
+            source=self.source,
+            content=json.dumps({"identifier": identifier}),
+            metadata={"identifier": identifier},
+            raw=payload,
+        )
+
+    def validate(self, document: Document) -> None:
+        identifier = document.metadata.get("identifier")
+        if not identifier:
+            raise ValueError("openFDA document missing identifier metadata")
+
+
+class DailyMedAdapter(HttpAdapter):
+    """Adapter for DailyMed SPL documents."""
+
+    source = "dailymed"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[str] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, setid: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        params = {"type": "spl", "setid": setid}
+        xml = await self.fetch_text("https://dailymed.nlm.nih.gov/dailymed/services/v2/spls", params=params)
+        yield xml
+
+    def parse(self, raw: Any) -> Document:
+        root = ET.fromstring(raw)
+        setid = root.find("setid").attrib.get("root") if root.find("setid") is not None else "unknown"
+        title = normalize_text(root.findtext("title", default=""))
+        sections: list[dict[str, Any]] = []
+        for section in root.findall("section"):
+            code_elem = section.find("code")
+            loinc = code_elem.attrib.get("code") if code_elem is not None else None
+            text = normalize_text(section.findtext("text", default=""))
+            sections.append({"loinc": loinc, "text": text})
+        payload = {"setid": setid, "title": title, "sections": sections}
+        content = canonical_json(payload)
+        effective = root.find("effectiveTime")
+        version = effective.attrib.get("value") if effective is not None else "unknown"
+        doc_id = self.build_doc_id(identifier=setid, version=version, content=content)
+        return Document(doc_id=doc_id, source=self.source, content=title, metadata={"setid": setid}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        setid = document.metadata.get("setid")
+        if not setid:
+            raise ValueError("DailyMed record missing setid")
+
+
+class RxNormAdapter(HttpAdapter):
+    """Adapter for RxNav / RxNorm lookups."""
+
+    source = "rxnorm"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, rxcui: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        payload = await self.fetch_json(f"https://rxnav.nlm.nih.gov/REST/rxcui/{rxcui}/properties.json")
+        yield payload
+
+    def parse(self, raw: Any) -> Document:
+        props = raw.get("properties", {})
+        rxcui = props.get("rxcui")
+        payload = {
+            "rxcui": rxcui,
+            "name": props.get("name"),
+            "synonym": props.get("synonym"),
+            "tty": props.get("tty"),
+            "ndc": props.get("ndc"),
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=str(rxcui), version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=props.get("name", ""), metadata={"rxcui": rxcui}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        rxcui = document.metadata.get("rxcui")
+        if not rxcui or not str(rxcui).isdigit():
+            raise ValueError("Invalid RxCUI")
+
+
+class UdiValidator:
+    """GTIN-14 validator for device identifiers."""
+
+    @staticmethod
+    def validate(value: str) -> bool:
+        if not _GTIN14_RE.match(value):
+            return False
+        digits = [int(c) for c in value]
+        checksum = 0
+        for index, digit in enumerate(reversed(digits[:-1]), start=1):
+            weight = 3 if index % 2 == 1 else 1
+            checksum += weight * digit
+        check_digit = (10 - (checksum % 10)) % 10
+        return check_digit == digits[-1]
+
+
+class AccessGudidAdapter(HttpAdapter):
+    """Adapter for AccessGUDID device registry."""
+
+    source = "accessgudid"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, udi_di: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        payload = await self.fetch_json("https://accessgudid.nlm.nih.gov/devices/lookup.json", params={"udi": udi_di})
+        yield payload
+
+    def parse(self, raw: Any) -> Document:
+        udi = raw.get("udi", {})
+        device_identifier = udi.get("deviceIdentifier") or raw.get("udi_di")
+        payload = {
+            "udi_di": device_identifier,
+            "brand": udi.get("brandName"),
+            "model": udi.get("versionOrModelNumber"),
+            "company": udi.get("companyName"),
+            "description": udi.get("deviceDescription"),
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=str(device_identifier), version="v1", content=content)
+        return Document(
+            doc_id=doc_id,
+            source=self.source,
+            content=json.dumps({"udi_di": device_identifier}),
+            metadata={"udi_di": device_identifier},
+            raw=payload,
+        )
+
+    def validate(self, document: Document) -> None:
+        udi_di = document.metadata.get("udi_di")
+        if not isinstance(udi_di, str) or not UdiValidator.validate(udi_di):
+            raise ValueError("Invalid UDI-DI")
+
+
+class OpenFdaUdiAdapter(OpenFdaAdapter):
+    """Specialized openFDA adapter for UDI endpoint with validation."""
+
+    source = "openfda_udi"
+
+    def parse(self, raw: Any) -> Document:  # pragma: no cover - delegate to super then enrich
+        document = super().parse(raw)
+        udi_di = raw.get("udi_di")
+        if udi_di:
+            document.metadata["udi_di"] = udi_di  # type: ignore[index]
+        return document
+
+    def validate(self, document: Document) -> None:
+        udi_di = document.metadata.get("udi_di")
+        if udi_di and not UdiValidator.validate(str(udi_di)):
+            raise ValueError("Invalid UDI-DI in openFDA payload")
+        super().validate(document)

--- a/src/Medical_KG/ingestion/adapters/guidelines.py
+++ b/src/Medical_KG/ingestion/adapters/guidelines.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from collections.abc import AsyncIterator, Iterable
+from typing import Any
+
+from Medical_KG.ingestion.adapters.base import AdapterContext
+from Medical_KG.ingestion.adapters.http import HttpAdapter
+from Medical_KG.ingestion.http_client import AsyncHttpClient
+from Medical_KG.ingestion.models import Document
+from Medical_KG.ingestion.utils import canonical_json, normalize_text
+
+
+class _BootstrapAdapter(HttpAdapter):
+    """Adapter base class that can iterate over bootstrap records."""
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[Any] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def _yield_bootstrap(self) -> AsyncIterator[Any]:
+        for record in self._bootstrap:
+            yield record
+
+
+class NiceGuidelineAdapter(_BootstrapAdapter):
+    source = "nice"
+
+    async def fetch(self, licence: str | None = None) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            async for record in self._yield_bootstrap():
+                yield record
+            return
+        params = {"licence": licence} if licence else None
+        payload = await self.fetch_json("https://api.nice.org.uk/guidance", params=params or {})
+        for record in payload.get("items", []):
+            yield record
+
+    def parse(self, raw: Any) -> Document:
+        payload = {
+            "uid": raw.get("uid"),
+            "title": normalize_text(raw.get("title", "")),
+            "summary": normalize_text(raw.get("summary", "")),
+            "url": raw.get("url"),
+            "licence": raw.get("licence"),
+        }
+        if not payload["uid"]:
+            raise ValueError("NICE guideline missing uid")
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=payload["uid"], version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=payload["summary"] or payload["title"], metadata={"uid": payload["uid"], "licence": payload["licence"]}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        licence = document.metadata.get("licence")
+        if licence not in {"OpenGov", "CC-BY-ND"}:
+            raise ValueError("Invalid NICE licence metadata")
+        if not document.metadata.get("uid"):
+            raise ValueError("NICE guideline missing uid metadata")
+
+
+class UspstfAdapter(_BootstrapAdapter):
+    source = "uspstf"
+
+    async def fetch(self, *_: Any, **__: Any) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            async for record in self._yield_bootstrap():
+                yield record
+            return
+        raise RuntimeError("USPSTF API requires manual approval; provide bootstrap records")
+
+    def parse(self, raw: Any) -> Document:
+        payload = {
+            "id": raw.get("id"),
+            "title": normalize_text(raw.get("title", "")),
+            "status": raw.get("status"),
+            "url": raw.get("url"),
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=payload["id"], version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=payload["title"], metadata={"id": payload["id"], "status": payload["status"]}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        if not document.metadata.get("status"):
+            raise ValueError("USPSTF record requires status")
+
+
+class CdcSocrataAdapter(_BootstrapAdapter):
+    source = "cdc_socrata"
+
+    async def fetch(self, dataset: str, *, limit: int = 1000) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            async for record in self._yield_bootstrap():
+                yield record
+            return
+        params = {"$limit": limit}
+        payload = await self.fetch_json(f"https://data.cdc.gov/resource/{dataset}.json", params=params)
+        for row in payload:
+            yield row
+
+    def parse(self, raw: Any) -> Document:
+        payload = dict(raw)
+        identifier = payload.get("row_id") or f"{payload.get('state')}-{payload.get('year')}-{payload.get('indicator')}"
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=identifier, version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"identifier": identifier}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        if not document.metadata.get("identifier"):
+            raise ValueError("CDC Socrata row missing identifier")
+
+
+class CdcWonderAdapter(_BootstrapAdapter):
+    source = "cdc_wonder"
+
+    async def fetch(self, *_: Any, **__: Any) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            async for record in self._yield_bootstrap():
+                yield record
+            return
+        raise RuntimeError("CDC WONDER requires XML form posts; provide bootstrap records")
+
+    def parse(self, raw: Any) -> Document:
+        root = ET.fromstring(raw)
+        rows = []
+        for row in root.findall(".//row"):
+            row_data: dict[str, str] = {}
+            for child in list(row):
+                row_data[child.tag] = normalize_text(child.text or "")
+            rows.append(row_data)
+        payload = {"rows": rows}
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=str(len(rows)), version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(rows), metadata={"rows": len(rows)}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        if document.metadata.get("rows", 0) == 0:
+            raise ValueError("CDC WONDER payload contained no rows")
+
+
+class WhoGhoAdapter(_BootstrapAdapter):
+    source = "who_gho"
+
+    async def fetch(self, indicator: str, *, spatial: str | None = None) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            async for record in self._yield_bootstrap():
+                yield record
+            return
+        params = {"indicator": indicator}
+        if spatial:
+            params["spatial"] = spatial
+        payload = await self.fetch_json("https://ghoapi.azureedge.net/api/GHO", params=params)
+        for entry in payload.get("value", []):
+            yield entry
+
+    def parse(self, raw: Any) -> Document:
+        payload = {
+            "indicator": raw.get("Indicator"),
+            "value": raw.get("Value"),
+            "country": raw.get("SpatialDim"),
+            "year": raw.get("TimeDim"),
+        }
+        identifier = f"{payload['indicator']}-{payload['country']}-{payload['year']}"
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=identifier, version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"identifier": identifier}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        if not document.metadata.get("identifier"):
+            raise ValueError("WHO GHO record missing identifier")
+
+
+class OpenPrescribingAdapter(_BootstrapAdapter):
+    source = "openprescribing"
+
+    async def fetch(self, endpoint: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            async for record in self._yield_bootstrap():
+                yield record
+            return
+        payload = await self.fetch_json(f"https://openprescribing.net/api/1.0/{endpoint}")
+        for row in payload:
+            yield row
+
+    def parse(self, raw: Any) -> Document:
+        payload = dict(raw)
+        identifier = payload.get("row_id") or payload.get("practice") or json.dumps(payload, sort_keys=True)
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=identifier, version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"identifier": identifier}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        if not document.metadata.get("identifier"):
+            raise ValueError("OpenPrescribing row missing identifier")

--- a/src/Medical_KG/ingestion/adapters/terminology.py
+++ b/src/Medical_KG/ingestion/adapters/terminology.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import AsyncIterator, Iterable
+from typing import Any
+
+from Medical_KG.ingestion.adapters.base import AdapterContext
+from Medical_KG.ingestion.adapters.http import HttpAdapter
+from Medical_KG.ingestion.http_client import AsyncHttpClient
+from Medical_KG.ingestion.models import Document
+from Medical_KG.ingestion.utils import canonical_json, normalize_text
+
+_MESH_ID_RE = re.compile(r"^D\d{6}")
+_UMLS_CUI_RE = re.compile(r"^C\d{7}")
+_LOINC_RE = re.compile(r"^\d{1,5}-\d{1,2}$")
+_ICD11_RE = re.compile(r"^[A-Z0-9]{3,4}")
+_SNOMED_RE = re.compile(r"^\d{6,18}$")
+
+
+class MeSHAdapter(HttpAdapter):
+    source = "mesh"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, descriptor_id: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        payload = await self.fetch_json("https://id.nlm.nih.gov/mesh/lookup/descriptor", params={"resource": descriptor_id})
+        yield payload
+
+    def parse(self, raw: Any) -> Document:
+        descriptor = raw.get("descriptor", {})
+        descriptor_id = descriptor.get("descriptorUI")
+        name = normalize_text(descriptor.get("descriptorName", {}).get("string", ""))
+        concept_list = descriptor.get("conceptList", {}).get("concept", []) or []
+        primary_concept = concept_list[0] if concept_list else {}
+        term_list = primary_concept.get("termList", {}).get("term", []) if isinstance(primary_concept, dict) else []
+        terms = [normalize_text(term.get("string", "")) for term in term_list if isinstance(term, dict)]
+        payload = {
+            "descriptor_id": descriptor_id,
+            "name": name,
+            "terms": terms,
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=descriptor_id, version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"descriptor_id": descriptor_id}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        descriptor_id = document.metadata.get("descriptor_id")
+        if not isinstance(descriptor_id, str) or not _MESH_ID_RE.match(descriptor_id):
+            raise ValueError("Invalid MeSH descriptor id")
+
+
+class UMLSAdapter(HttpAdapter):
+    source = "umls"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, cui: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        payload = await self.fetch_json("https://uts-ws.nlm.nih.gov/rest/content/current/CUI/" + cui)
+        yield payload
+
+    def parse(self, raw: Any) -> Document:
+        result = raw.get("result", {})
+        cui = result.get("ui")
+        payload = {
+            "cui": cui,
+            "name": result.get("name"),
+            "synonyms": result.get("synonyms", []),
+            "definition": result.get("definition"),
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=cui, version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"cui": cui}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        cui = document.metadata.get("cui")
+        if not isinstance(cui, str) or not _UMLS_CUI_RE.match(cui):
+            raise ValueError("Invalid UMLS CUI")
+
+
+class LoincAdapter(HttpAdapter):
+    source = "loinc"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, code: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        payload = await self.fetch_json("https://fhir.loinc.org/CodeSystem/$lookup", params={"code": code})
+        yield payload
+
+    def parse(self, raw: Any) -> Document:
+        code = raw.get("parameter", {}).get("code") or raw.get("code")
+        payload = {
+            "code": code,
+            "display": raw.get("display"),
+            "property": raw.get("property"),
+            "system": raw.get("system"),
+            "method": raw.get("method"),
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=str(code), version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"code": code}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        code = document.metadata.get("code")
+        if not isinstance(code, str) or not _LOINC_RE.match(code):
+            raise ValueError("Invalid LOINC code")
+
+
+class Icd11Adapter(HttpAdapter):
+    source = "icd11"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, code: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        payload = await self.fetch_json(f"https://id.who.int/icd/release/11/mms/{code}")
+        yield payload
+
+    def parse(self, raw: Any) -> Document:
+        code = raw.get("code")
+        payload = {
+            "code": code,
+            "title": raw.get("title", {}).get("@value"),
+            "definition": raw.get("definition", {}).get("@value"),
+            "uri": raw.get("browserUrl"),
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=str(code), version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"code": code}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        code = document.metadata.get("code")
+        if not isinstance(code, str) or not _ICD11_RE.match(code):
+            raise ValueError("Invalid ICD-11 code")
+
+
+class SnomedAdapter(HttpAdapter):
+    source = "snomed"
+
+    def __init__(
+        self,
+        context: AdapterContext,
+        client: AsyncHttpClient,
+        *,
+        bootstrap_records: Iterable[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(context, client)
+        self._bootstrap = list(bootstrap_records or [])
+
+    async def fetch(self, code: str) -> AsyncIterator[Any]:
+        if self._bootstrap:
+            for record in self._bootstrap:
+                yield record
+            return
+        payload = await self.fetch_json("https://snowstorm.snomedserver.org/fhir/CodeSystem/$lookup", params={"code": code})
+        yield payload
+
+    def parse(self, raw: Any) -> Document:
+        code = raw.get("code") or raw.get("parameter", {}).get("code")
+        display = raw.get("display")
+        payload = {
+            "code": code,
+            "display": display,
+            "designation": raw.get("designation", []),
+        }
+        content = canonical_json(payload)
+        doc_id = self.build_doc_id(identifier=str(code), version="v1", content=content)
+        return Document(doc_id=doc_id, source=self.source, content=json.dumps(payload), metadata={"code": code}, raw=payload)
+
+    def validate(self, document: Document) -> None:
+        code = document.metadata.get("code")
+        if not isinstance(code, str) or not _SNOMED_RE.match(code):
+            raise ValueError("Invalid SNOMED CT code")
+        if not document.raw.get("designation"):
+            raise ValueError("SNOMED record missing designation list")

--- a/src/Medical_KG/ingestion/cli.py
+++ b/src/Medical_KG/ingestion/cli.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+import typer
+
+from Medical_KG.ingestion.adapters.base import AdapterContext
+from Medical_KG.ingestion.http_client import AsyncHttpClient
+from Medical_KG.ingestion.ledger import IngestionLedger
+from Medical_KG.ingestion.registry import available_sources, get_adapter
+
+app = typer.Typer(help="Medical KG ingestion CLI")
+
+
+def _load_batch(path: Path) -> Iterable[dict[str, Any]]:
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        yield json.loads(line)
+
+
+@app.command("ingest")
+def ingest(
+    source: str = typer.Argument(..., help="Source identifier", autocompletion=lambda: available_sources()),
+    batch: Path | None = typer.Option(None, help="Path to NDJSON with parameters"),
+    auto: bool = typer.Option(False, help="Enable auto pipeline"),
+    ledger_path: Path = typer.Option(Path(".ingest-ledger.jsonl"), help="Ledger storage"),
+) -> None:
+    """Run ingestion for the specified source."""
+
+    if source not in available_sources():
+        raise typer.BadParameter(f"Unknown source '{source}'. Known sources: {', '.join(available_sources())}")
+
+    ledger = IngestionLedger(ledger_path)
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    adapter = get_adapter(source, context, client)
+
+    async def _run() -> None:
+        try:
+            if batch:
+                for params in _load_batch(batch):
+                    results = await adapter.run(**params)
+                    if auto:
+                        typer.echo(json.dumps([res.document.doc_id for res in results]))
+            else:
+                results = await adapter.run()
+                if auto:
+                    typer.echo(json.dumps([res.document.doc_id for res in results]))
+        finally:
+            await client.aclose()
+
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/Medical_KG/ingestion/registry.py
+++ b/src/Medical_KG/ingestion/registry.py
@@ -1,0 +1,80 @@
+"""Adapter registry for ingestion CLI and orchestration."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Type
+
+from Medical_KG.ingestion.adapters.base import AdapterContext, BaseAdapter
+from Medical_KG.ingestion.adapters.clinical import (
+    AccessGudidAdapter,
+    ClinicalTrialsGovAdapter,
+    DailyMedAdapter,
+    OpenFdaAdapter,
+    OpenFdaUdiAdapter,
+    RxNormAdapter,
+)
+from Medical_KG.ingestion.adapters.guidelines import (
+    CdcSocrataAdapter,
+    CdcWonderAdapter,
+    NiceGuidelineAdapter,
+    OpenPrescribingAdapter,
+    UspstfAdapter,
+    WhoGhoAdapter,
+)
+from Medical_KG.ingestion.adapters.literature import MedRxivAdapter, PmcAdapter, PubMedAdapter
+from Medical_KG.ingestion.adapters.terminology import (
+    Icd11Adapter,
+    LoincAdapter,
+    MeSHAdapter,
+    SnomedAdapter,
+    UMLSAdapter,
+)
+from Medical_KG.ingestion.http_client import AsyncHttpClient
+
+AdapterFactory = Callable[[AdapterContext, AsyncHttpClient], BaseAdapter]
+
+
+def _register() -> Dict[str, AdapterFactory]:
+    def factory(cls: Type[BaseAdapter]) -> AdapterFactory:
+        def _builder(context: AdapterContext, client: AsyncHttpClient, **kwargs: Any) -> BaseAdapter:
+            return cls(context, client, **kwargs)
+
+        return _builder
+
+    return {
+        "pubmed": factory(PubMedAdapter),
+        "pmc": factory(PmcAdapter),
+        "medrxiv": factory(MedRxivAdapter),
+        "clinicaltrials": factory(ClinicalTrialsGovAdapter),
+        "openfda": factory(OpenFdaAdapter),
+        "dailymed": factory(DailyMedAdapter),
+        "rxnorm": factory(RxNormAdapter),
+        "mesh": factory(MeSHAdapter),
+        "umls": factory(UMLSAdapter),
+        "loinc": factory(LoincAdapter),
+        "icd11": factory(Icd11Adapter),
+        "snomed": factory(SnomedAdapter),
+        "nice": factory(NiceGuidelineAdapter),
+        "uspstf": factory(UspstfAdapter),
+        "cdc_socrata": factory(CdcSocrataAdapter),
+        "cdc_wonder": factory(CdcWonderAdapter),
+        "who_gho": factory(WhoGhoAdapter),
+        "openprescribing": factory(OpenPrescribingAdapter),
+        "accessgudid": factory(AccessGudidAdapter),
+        "openfda_udi": factory(OpenFdaUdiAdapter),
+    }
+
+
+_REGISTRY = _register()
+
+
+def get_adapter(source: str, context: AdapterContext, client: AsyncHttpClient, **kwargs: Any) -> BaseAdapter:
+    try:
+        factory = _REGISTRY[source]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown adapter source: {source}") from exc
+    return factory(context, client, **kwargs)
+
+
+def available_sources() -> list[str]:
+    return sorted(_REGISTRY)

--- a/src/Medical_KG/ir/__init__.py
+++ b/src/Medical_KG/ir/__init__.py
@@ -1,0 +1,16 @@
+"""Intermediate representation (IR) normalization utilities."""
+
+from .models import Block, DocumentIR, SpanMap, Table
+from .normalizer import NormalizedText, TextNormalizer
+from .validator import IRValidator, ValidationError
+
+__all__ = [
+    "Block",
+    "DocumentIR",
+    "SpanMap",
+    "Table",
+    "NormalizedText",
+    "TextNormalizer",
+    "IRValidator",
+    "ValidationError",
+]

--- a/src/Medical_KG/ir/builder.py
+++ b/src/Medical_KG/ir/builder.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from Medical_KG.ir.models import Block, DocumentIR, Table
+from Medical_KG.ir.normalizer import TextNormalizer, section_from_heading
+
+
+class IrBuilder:
+    """Base builder converting source payloads into IR objects."""
+
+    def __init__(self, *, normalizer: TextNormalizer | None = None) -> None:
+        self.normalizer = normalizer or TextNormalizer()
+
+    def build(self, *, doc_id: str, source: str, uri: str, text: str, metadata: Mapping[str, Any]) -> DocumentIR:
+        normalized = self.normalizer.normalize(text)
+        document = DocumentIR(
+            doc_id=doc_id,
+            source=source,
+            uri=uri,
+            language=normalized.language,
+            text=normalized.text,
+            raw_text=normalized.raw_text,
+        )
+        document.span_map = normalized.span_map
+        document.provenance.update(metadata.get("provenance", {}))
+        return document
+
+
+class ClinicalTrialsBuilder(IrBuilder):
+    def build_from_study(self, *, doc_id: str, uri: str, study: Mapping[str, Any]) -> DocumentIR:
+        sections: list[tuple[str, str, str]] = []
+        for name in ("title", "status", "eligibility"):
+            value = study.get(name, "") or ""
+            if value:
+                normalized = self.normalizer.normalize(str(value))
+                sections.append((name, normalized.text, str(value)))
+        combined_text = "\n\n".join(section_text for _, section_text, _ in sections) if sections else ""
+        document = super().build(doc_id=doc_id, source="clinicaltrials", uri=uri, text=combined_text, metadata={})
+        offset = 0
+        for index, (section, section_text, raw_value) in enumerate(sections):
+            start = offset
+            end = start + len(section_text)
+            block_type = "heading" if section == "title" else "paragraph"
+            document.add_block(
+                Block(
+                    type=block_type,
+                    text=section_text,
+                    start=start,
+                    end=end,
+                    section=section,
+                    meta={"raw": raw_value},
+                )
+            )
+            offset = end
+            if index < len(sections) - 1:
+                offset += 2  # account for double newline separator
+        return document
+
+
+class PmcBuilder(IrBuilder):
+    def build_from_article(self, *, doc_id: str, uri: str, article: Mapping[str, Any]) -> DocumentIR:
+        text = article.get("abstract", "")
+        document = super().build(doc_id=doc_id, source="pmc", uri=uri, text=text, metadata={})
+        blocks: Iterable[Mapping[str, Any]] = article.get("sections", [])  # type: ignore[assignment]
+        offset = 0
+        for block in blocks:
+            heading = block.get("heading", "")
+            normalized = self.normalizer.normalize(block.get("text", ""))
+            start = offset
+            end = start + len(normalized.text)
+            document.add_block(
+                Block(
+                    type="heading" if heading else "paragraph",
+                    text=normalized.text,
+                    start=start,
+                    end=end,
+                    section=section_from_heading(heading) if heading else "body",
+                    meta={"heading": heading},
+                )
+            )
+            offset = end + 1
+        for table_payload in article.get("tables", []):
+            caption = table_payload.get("caption", "")
+            headers = table_payload.get("headers", [])
+            rows = table_payload.get("rows", [])
+            start = offset
+            end = start + len(caption)
+            document.add_table(Table(caption=caption, headers=headers, rows=rows, start=start, end=end, meta={}))
+            offset = end + 1
+        return document

--- a/src/Medical_KG/ir/models.py
+++ b/src/Medical_KG/ir/models.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, MutableMapping, Sequence
+
+
+@dataclass(slots=True)
+class Span:
+    raw_start: int
+    raw_end: int
+    canonical_start: int
+    canonical_end: int
+    transform: str
+
+
+@dataclass(slots=True)
+class SpanMap:
+    spans: List[Span] = field(default_factory=list)
+
+    def add(self, raw_start: int, raw_end: int, canonical_start: int, canonical_end: int, transform: str) -> None:
+        self.spans.append(Span(raw_start, raw_end, canonical_start, canonical_end, transform))
+
+    def to_list(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "raw_start": span.raw_start,
+                "raw_end": span.raw_end,
+                "canonical_start": span.canonical_start,
+                "canonical_end": span.canonical_end,
+                "transform": span.transform,
+            }
+            for span in self.spans
+        ]
+
+
+@dataclass(slots=True)
+class Block:
+    type: str
+    text: str
+    start: int
+    end: int
+    section: str | None = None
+    meta: MutableMapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class Table:
+    caption: str
+    headers: List[str]
+    rows: List[List[str]]
+    start: int
+    end: int
+    meta: MutableMapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class DocumentIR:
+    doc_id: str
+    source: str
+    uri: str
+    language: str
+    text: str
+    raw_text: str
+    blocks: List[Block] = field(default_factory=list)
+    tables: List[Table] = field(default_factory=list)
+    span_map: SpanMap = field(default_factory=SpanMap)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    provenance: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def add_block(self, block: Block) -> None:
+        self.blocks.append(block)
+
+    def add_table(self, table: Table) -> None:
+        self.tables.append(table)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "doc_id": self.doc_id,
+            "source": self.source,
+            "uri": self.uri,
+            "language": self.language,
+            "text": self.text,
+            "raw_text": self.raw_text,
+            "blocks": [
+                {
+                    "type": block.type,
+                    "text": block.text,
+                    "start": block.start,
+                    "end": block.end,
+                    "section": block.section,
+                    "meta": dict(block.meta),
+                }
+                for block in self.blocks
+            ],
+            "tables": [
+                {
+                    "caption": table.caption,
+                    "headers": table.headers,
+                    "rows": table.rows,
+                    "start": table.start,
+                    "end": table.end,
+                    "meta": dict(table.meta),
+                }
+                for table in self.tables
+            ],
+            "span_map": self.span_map.to_list(),
+            "created_at": self.created_at.isoformat(),
+            "provenance": dict(self.provenance),
+        }
+
+
+def ensure_monotonic_spans(blocks: Sequence[Block]) -> None:
+    previous_end = -1
+    for block in blocks:
+        if block.start < previous_end:
+            raise ValueError("Block spans must be monotonic")
+        if block.start > block.end:
+            raise ValueError("Invalid block span offsets")
+        previous_end = block.end

--- a/src/Medical_KG/ir/normalizer.py
+++ b/src/Medical_KG/ir/normalizer.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Iterable
+
+from langdetect import detect
+
+from Medical_KG.ir.models import SpanMap
+
+_DEHYPHENATION_DICTIONARY = {
+    "treatment",
+    "therapy",
+    "monitoring",
+    "sepsis",
+    "lactate",
+    "cardiovascular",
+}
+
+
+@dataclass(slots=True)
+class NormalizedText:
+    text: str
+    raw_text: str
+    span_map: SpanMap
+    language: str
+
+
+class TextNormalizer:
+    """Canonicalizes text content while tracking span offsets."""
+
+    def __init__(self, *, dictionary: Iterable[str] | None = None) -> None:
+        self.dictionary = set(dictionary or _DEHYPHENATION_DICTIONARY)
+
+    def normalize(self, text: str) -> NormalizedText:
+        raw_text = text
+        normalized = unicodedata.normalize("NFC", text)
+        normalized = self._collapse_whitespace(normalized)
+        normalized = self._dehyphenate(normalized)
+        language = self._detect_language(normalized)
+        span_map = SpanMap()
+        span_map.add(0, len(raw_text), 0, len(normalized), "normalize")
+        return NormalizedText(text=normalized, raw_text=raw_text, span_map=span_map, language=language)
+
+    def _collapse_whitespace(self, text: str) -> str:
+        normalized_lines = []
+        for line in text.splitlines():
+            normalized_lines.append(" ".join(line.split()))
+        return "\n".join(normalized_lines)
+
+    def _dehyphenate(self, text: str) -> str:
+        pattern = re.compile(r"([A-Za-z]+)-\n([A-Za-z]+)")
+        result: list[str] = []
+        last_index = 0
+        for match in pattern.finditer(text):
+            result.append(text[last_index : match.start()])
+            prefix, suffix = match.group(1), match.group(2)
+            candidate = prefix + suffix
+            if candidate.lower() in self.dictionary:
+                result.append(candidate)
+            else:
+                result.append(f"{prefix}-{suffix}")
+            last_index = match.end()
+        result.append(text[last_index:])
+        return "".join(result)
+
+    def _detect_language(self, text: str) -> str:
+        try:
+            code = detect(text)
+        except Exception:  # pragma: no cover - third-party failures
+            return "unknown"
+        return code[:2]
+
+
+def section_from_heading(heading: str, *, default: str = "other") -> str:
+    heading_lower = heading.lower()
+    if "introduction" in heading_lower:
+        return "introduction"
+    if "methods" in heading_lower:
+        return "methods"
+    if "results" in heading_lower:
+        return "results"
+    if "discussion" in heading_lower:
+        return "discussion"
+    return default

--- a/src/Medical_KG/ir/schemas/block.schema.json
+++ b/src/Medical_KG/ir/schemas/block.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://medical-kg.dev/schemas/block.v1.schema.json",
+  "type": "object",
+  "required": ["type", "text", "start", "end"],
+  "properties": {
+    "type": {"type": "string"},
+    "text": {"type": "string"},
+    "start": {"type": "integer", "minimum": 0},
+    "end": {"type": "integer", "minimum": 0},
+    "section": {"type": ["string", "null"]},
+    "meta": {"type": "object"}
+  },
+  "additionalProperties": false
+}

--- a/src/Medical_KG/ir/schemas/document.schema.json
+++ b/src/Medical_KG/ir/schemas/document.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://medical-kg.dev/schemas/document.v1.schema.json",
+  "type": "object",
+  "required": ["doc_id", "source", "uri", "language", "text", "raw_text", "blocks", "tables", "span_map"],
+  "properties": {
+    "doc_id": {"type": "string"},
+    "source": {"type": "string"},
+    "uri": {"type": "string"},
+    "language": {"type": "string", "pattern": "^[a-z]{2}$"},
+    "text": {"type": "string"},
+    "raw_text": {"type": "string"},
+    "blocks": {
+      "type": "array",
+      "items": {"$ref": "block.schema.json"}
+    },
+    "tables": {
+      "type": "array",
+      "items": {"$ref": "table.schema.json"}
+    },
+    "span_map": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["raw_start", "raw_end", "canonical_start", "canonical_end", "transform"],
+        "properties": {
+          "raw_start": {"type": "integer", "minimum": 0},
+          "raw_end": {"type": "integer", "minimum": 0},
+          "canonical_start": {"type": "integer", "minimum": 0},
+          "canonical_end": {"type": "integer", "minimum": 0},
+          "transform": {"type": "string"}
+        }
+      }
+    },
+    "provenance": {"type": "object"}
+  },
+  "additionalProperties": false
+}

--- a/src/Medical_KG/ir/schemas/table.schema.json
+++ b/src/Medical_KG/ir/schemas/table.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://medical-kg.dev/schemas/table.v1.schema.json",
+  "type": "object",
+  "required": ["caption", "headers", "rows", "start", "end"],
+  "properties": {
+    "caption": {"type": "string"},
+    "headers": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "rows": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "start": {"type": "integer", "minimum": 0},
+    "end": {"type": "integer", "minimum": 0},
+    "meta": {"type": "object"}
+  },
+  "additionalProperties": false
+}

--- a/src/Medical_KG/ir/storage.py
+++ b/src/Medical_KG/ir/storage.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from Medical_KG.ir.models import DocumentIR
+
+
+class IrStorage:
+    """Simple content-addressable storage using JSONL files."""
+
+    def __init__(self, base_path: Path) -> None:
+        self.base_path = base_path
+
+    def write(self, document: DocumentIR) -> Path:
+        payload = document.as_dict()
+        encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+        digest = hashlib.sha256(encoded).hexdigest()
+        filename = f"{document.doc_id}-{digest[:12]}.json"
+        path = self.base_path / document.source / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists() and path.read_bytes() == encoded:
+            return path
+        path.write_bytes(encoded)
+        return path
+
+    def iter_documents(self, source: str) -> Iterable[dict[str, Any]]:
+        directory = self.base_path / source
+        if not directory.exists():
+            return []
+        documents: list[dict[str, Any]] = []
+        for file in directory.glob("**/*"):
+            if file.is_file():
+                data = json.loads(file.read_text())
+                documents.append(data)
+        return documents

--- a/src/Medical_KG/ir/validator.py
+++ b/src/Medical_KG/ir/validator.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+try:  # pragma: no cover - optional dependency
+    from jsonschema import Draft202012Validator, ValidationError as _JsonSchemaError
+except ModuleNotFoundError:  # pragma: no cover - fallback for lightweight environments
+    class _JsonSchemaError(Exception):
+        def __init__(self, message: str) -> None:
+            super().__init__(message)
+            self.message = message
+
+    class Draft202012Validator:  # type: ignore[override]
+        def __init__(self, schema: Mapping[str, Any]) -> None:
+            self.schema = schema
+
+        def validate(self, instance: Mapping[str, Any]) -> None:
+            required = self.schema.get("required", [])
+            for field in required:
+                if field not in instance:
+                    raise _JsonSchemaError(f"Missing required field '{field}'")
+
+from Medical_KG.ir.models import DocumentIR, ensure_monotonic_spans
+
+
+class ValidationError(Exception):
+    pass
+
+
+class IRValidator:
+    def __init__(self, *, schema_dir: Path | None = None) -> None:
+        base = schema_dir or Path(__file__).resolve().parent / "schemas"
+        self.document_schema = self._load_schema(base / "document.schema.json")
+        self.block_schema = self._load_schema(base / "block.schema.json")
+        self.table_schema = self._load_schema(base / "table.schema.json")
+        self.document_validator = Draft202012Validator(self.document_schema)
+        self.block_validator = Draft202012Validator(self.block_schema)
+        self.table_validator = Draft202012Validator(self.table_schema)
+
+    def _load_schema(self, path: Path) -> Mapping[str, Any]:
+        return json.loads(path.read_text())
+
+    def validate_document(self, document: DocumentIR) -> None:
+        payload = document.as_dict()
+        try:
+            self.document_validator.validate(payload)
+        except _JsonSchemaError as exc:
+            raise ValidationError(f"Document schema validation failed: {exc.message}") from exc
+
+        for block_payload in payload["blocks"]:
+            try:
+                self.block_validator.validate(block_payload)
+            except _JsonSchemaError as exc:
+                raise ValidationError(f"Block validation failed: {exc.message}") from exc
+
+        for table_payload in payload["tables"]:
+            try:
+                self.table_validator.validate(table_payload)
+            except _JsonSchemaError as exc:
+                raise ValidationError(f"Table validation failed: {exc.message}") from exc
+
+        try:
+            ensure_monotonic_spans(document.blocks)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+        self._validate_offsets(document)
+
+    def _validate_offsets(self, document: DocumentIR) -> None:
+        text_length = len(document.text)
+        for block in document.blocks:
+            if block.end > text_length:
+                raise ValidationError("Block span exceeds document length")
+        for table in document.tables:
+            if table.end < table.start:
+                raise ValidationError("Table span invalid")

--- a/src/Medical_KG/kg/__init__.py
+++ b/src/Medical_KG/kg/__init__.py
@@ -1,0 +1,14 @@
+"""Knowledge graph schema management and writers."""
+
+from .schema import CDKOSchema
+from .writer import KnowledgeGraphWriter
+from .validators import KgValidator, KgValidationError
+from .fhir import EvidenceExporter
+
+__all__ = [
+    "CDKOSchema",
+    "KnowledgeGraphWriter",
+    "KgValidator",
+    "KgValidationError",
+    "EvidenceExporter",
+]

--- a/src/Medical_KG/kg/fhir.py
+++ b/src/Medical_KG/kg/fhir.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(slots=True)
+class FhirResource:
+    resource_type: str
+    payload: Mapping[str, Any]
+
+
+class EvidenceExporter:
+    """Converts KG nodes to simplified FHIR resources."""
+
+    def export_evidence(self, node: Mapping[str, Any]) -> FhirResource:
+        statistic = {
+            "statisticType": node.get("type"),
+            "value": node.get("value"),
+            "sampleSize": node.get("n_total"),
+        }
+        if node.get("ci_low") is not None and node.get("ci_high") is not None:
+            statistic["confidenceInterval"] = {
+                "low": node["ci_low"],
+                "high": node["ci_high"],
+            }
+        payload = {
+            "resourceType": "Evidence",
+            "id": node.get("id"),
+            "status": "active",
+            "variableDefinition": node.get("variables", []),
+            "statistic": [statistic],
+            "note": node.get("notes", []),
+        }
+        return FhirResource(resource_type="Evidence", payload=payload)
+
+    def export_evidence_variable(self, node: Mapping[str, Any]) -> FhirResource:
+        payload = {
+            "resourceType": "EvidenceVariable",
+            "id": node.get("id"),
+            "name": node.get("name"),
+            "status": "active",
+            "characteristic": node.get("characteristic", []),
+        }
+        return FhirResource(resource_type="EvidenceVariable", payload=payload)

--- a/src/Medical_KG/kg/schema.py
+++ b/src/Medical_KG/kg/schema.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass(slots=True)
+class Constraint:
+    statement: str
+    description: str
+
+
+@dataclass(slots=True)
+class Index:
+    statement: str
+    description: str
+
+
+@dataclass(slots=True)
+class CDKOSchema:
+    constraints: List[Constraint] = field(default_factory=list)
+    indexes: List[Index] = field(default_factory=list)
+
+    @classmethod
+    def default(cls) -> "CDKOSchema":
+        constraints = [
+            Constraint("CREATE CONSTRAINT doc_uri_unique IF NOT EXISTS FOR (d:Document) REQUIRE d.uri IS UNIQUE", "Unique document URIs"),
+            Constraint("CREATE CONSTRAINT chunk_id_unique IF NOT EXISTS FOR (c:Chunk) REQUIRE c.id IS UNIQUE", "Chunk id uniqueness"),
+            Constraint("CREATE CONSTRAINT study_nct_unique IF NOT EXISTS FOR (s:Study) REQUIRE s.nct_id IS UNIQUE", "Study id uniqueness"),
+            Constraint("CREATE CONSTRAINT drug_rxcui_unique IF NOT EXISTS FOR (d:Drug) REQUIRE d.rxcui IS UNIQUE", "Drug RxCUI uniqueness"),
+            Constraint("CREATE CONSTRAINT device_udi_unique IF NOT EXISTS FOR (x:Device) REQUIRE x.udi_di IS UNIQUE", "Device UDI uniqueness"),
+        ]
+        indexes = [
+            Index("CREATE VECTOR INDEX chunk_qwen_idx IF NOT EXISTS FOR (c:Chunk) ON (c.embedding_qwen) OPTIONS {indexConfig: {`vector.dimensions`: 4096, `vector.similarity_function`: 'cosine'}}", "Chunk embedding vector index"),
+            Index("CREATE FULLTEXT INDEX chunk_text_ft IF NOT EXISTS FOR (n:Chunk) ON EACH [n.text] OPTIONS {analyzer: 'english'}", "Chunk full text index"),
+        ]
+        return cls(constraints=constraints, indexes=indexes)
+
+    def as_statements(self) -> Dict[str, List[str]]:
+        return {
+            "constraints": [c.statement for c in self.constraints],
+            "indexes": [i.statement for i in self.indexes],
+        }

--- a/src/Medical_KG/kg/validators.py
+++ b/src/Medical_KG/kg/validators.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+class KgValidationError(Exception):
+    pass
+
+
+@dataclass(slots=True)
+class ValidationIssue:
+    node_id: str
+    reason: str
+
+
+class KgValidator:
+    """Lightweight validator emulating SHACL rules."""
+
+    def __init__(self, *, ucum_codes: Iterable[str] | None = None) -> None:
+        self.ucum_codes = set(ucum_codes or {"1", "mg", "kg", "mL"})
+
+    def validate_ucum(self, node: Mapping[str, Any]) -> None:
+        unit = node.get("unit_ucum") or node.get("unit")
+        if unit and unit not in self.ucum_codes:
+            raise KgValidationError(f"Invalid UCUM code: {unit}")
+
+    def validate_spans(self, node: Mapping[str, Any]) -> None:
+        spans = node.get("spans_json")
+        if spans:
+            for span in spans:
+                start = span.get("start")
+                end = span.get("end")
+                length = span.get("length", 0)
+                if start is None or end is None or start < 0 or end < 0 or end < start:
+                    raise KgValidationError("Invalid span offsets")
+                if length and end - start != length:
+                    raise KgValidationError("Span length mismatch")
+        else:
+            raise KgValidationError("spans_json missing or empty")
+
+    def ensure_provenance(self, node: Mapping[str, Any]) -> None:
+        provenance = node.get("provenance", [])
+        if not provenance:
+            raise KgValidationError("Node missing provenance references")
+
+    def validate_relationship(self, relationship: Mapping[str, Any]) -> None:
+        if relationship.get("type") == "HAS_AE":
+            count = relationship.get("count", 0)
+            if count < 0:
+                raise KgValidationError("Adverse event count must be non-negative")
+            grade = relationship.get("grade")
+            if grade is not None and grade not in {1, 2, 3, 4, 5}:
+                raise KgValidationError("Grade must be between 1 and 5")
+
+    def validate_node(self, node: Mapping[str, Any]) -> None:
+        label = node.get("label")
+        if label in {"Evidence", "Outcome"}:
+            self.validate_ucum(node)
+        if label in {"Evidence", "EvidenceVariable", "EligibilityConstraint"}:
+            self.ensure_provenance(node)
+        if "spans_json" in node:
+            self.validate_spans(node)

--- a/src/Medical_KG/kg/writer.py
+++ b/src/Medical_KG/kg/writer.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping
+
+
+@dataclass(slots=True)
+class WriteStatement:
+    cypher: str
+    parameters: Dict[str, Any]
+
+
+class KnowledgeGraphWriter:
+    """Generates Cypher statements for Neo4j upserts."""
+
+    def __init__(self) -> None:
+        self._statements: list[WriteStatement] = []
+
+    @property
+    def statements(self) -> Iterable[WriteStatement]:
+        return list(self._statements)
+
+    def write_document(self, payload: Mapping[str, Any]) -> None:
+        cypher = (
+            "MERGE (d:Document {id: $id}) "
+            "SET d += {source: $source, uri: $uri, title: $title, language: $language, publication_date: $publication_date, meta: $meta, updated_at: timestamp()}"
+        )
+        params = {
+            "id": payload["id"],
+            "source": payload.get("source"),
+            "uri": payload.get("uri"),
+            "title": payload.get("title"),
+            "language": payload.get("language"),
+            "publication_date": payload.get("publication_date"),
+            "meta": payload.get("meta", {}),
+        }
+        self._statements.append(WriteStatement(cypher=cypher, parameters=params))
+
+    def write_chunk(self, payload: Mapping[str, Any]) -> None:
+        cypher = (
+            "MERGE (c:Chunk {id: $id}) SET c += {text: $text, section: $section, start: $start, end: $end, token_count: $token_count, intent: $intent, path: $path}"  # noqa: E501
+        )
+        params = {
+            "id": payload["id"],
+            "text": payload.get("text"),
+            "section": payload.get("section"),
+            "start": payload.get("start"),
+            "end": payload.get("end"),
+            "token_count": payload.get("token_count"),
+            "intent": payload.get("intent"),
+            "path": payload.get("path"),
+        }
+        self._statements.append(WriteStatement(cypher=cypher, parameters=params))
+
+    def write_relationship(self, rel_type: str, start_id: str, end_id: str, properties: Mapping[str, Any] | None = None) -> None:
+        cypher = (
+            "MATCH (a {id: $start_id}) MATCH (b {id: $end_id}) "
+            f"MERGE (a)-[r:{rel_type}]->(b) SET r += $properties"
+        )
+        params = {"start_id": start_id, "end_id": end_id, "properties": dict(properties or {})}
+        self._statements.append(WriteStatement(cypher=cypher, parameters=params))
+
+    def clear(self) -> None:
+        self._statements.clear()

--- a/tests/fixtures/ingestion/accessgudid.json
+++ b/tests/fixtures/ingestion/accessgudid.json
@@ -1,0 +1,9 @@
+{
+  "udi": {
+    "deviceIdentifier": "00380740000011",
+    "brandName": "DeviceX",
+    "versionOrModelNumber": "Model1",
+    "companyName": "DeviceCorp",
+    "deviceDescription": "A medical device"
+  }
+}

--- a/tests/fixtures/ingestion/cdc_socrata.json
+++ b/tests/fixtures/ingestion/cdc_socrata.json
@@ -1,0 +1,8 @@
+[
+  {
+    "indicator": "Vaccination coverage",
+    "value": "85.5",
+    "state": "CA",
+    "year": "2023"
+  }
+]

--- a/tests/fixtures/ingestion/cdc_wonder.xml
+++ b/tests/fixtures/ingestion/cdc_wonder.xml
@@ -1,0 +1,9 @@
+<response>
+  <data>
+    <row>
+      <cause>Influenza</cause>
+      <deaths>100</deaths>
+      <year>2023</year>
+    </row>
+  </data>
+</response>

--- a/tests/fixtures/ingestion/ctgov_study.json
+++ b/tests/fixtures/ingestion/ctgov_study.json
@@ -1,0 +1,46 @@
+{
+  "protocolSection": {
+    "identificationModule": {
+      "nctId": "NCT01234567",
+      "briefTitle": "Study of Lactate"
+    },
+    "statusModule": {
+      "overallStatus": "Completed"
+    },
+    "descriptionModule": {
+      "briefSummary": "A study on lactate clearance.",
+      "detailedDescription": "Detailed description"
+    },
+    "designModule": {
+      "phases": ["Phase 2"],
+      "studyType": "Interventional"
+    },
+    "armsInterventionsModule": {
+      "arms": [
+        {
+          "armId": "A1",
+          "name": "Treatment",
+          "type": "Experimental",
+          "description": "Lactate guided therapy"
+        }
+      ]
+    },
+    "eligibilityModule": {
+      "eligibilityCriteria": "Inclusion: Age > 18\nExclusion: Pregnancy"
+    },
+    "outcomesModule": {
+      "primaryOutcomes": [
+        {
+          "measure": "Mortality",
+          "description": "28-day mortality",
+          "timeFrame": "28 days"
+        }
+      ]
+    }
+  },
+  "derivedSection": {
+    "miscInfoModule": {
+      "version": "2024-01-01"
+    }
+  }
+}

--- a/tests/fixtures/ingestion/dailymed_spl.xml
+++ b/tests/fixtures/ingestion/dailymed_spl.xml
@@ -1,0 +1,10 @@
+<document>
+  <setid root="11111111-2222-3333-4444-555555555555" />
+  <effectiveTime value="20240101" />
+  <title>DrugY Injection</title>
+  <section>
+    <code code="34067-9" />
+    <title>INDICATIONS AND USAGE</title>
+    <text>This drug is indicated for...</text>
+  </section>
+</document>

--- a/tests/fixtures/ingestion/icd11_code.json
+++ b/tests/fixtures/ingestion/icd11_code.json
@@ -1,0 +1,6 @@
+{
+  "code": "1A00",
+  "title": {"@value": "Cholera"},
+  "definition": {"@value": "An infection"},
+  "browserUrl": "https://icd.who.int/browse11/l-m/en#/http://id.who.int/icd/entity/10001123"
+}

--- a/tests/fixtures/ingestion/loinc_lookup.json
+++ b/tests/fixtures/ingestion/loinc_lookup.json
@@ -1,0 +1,9 @@
+{
+  "parameter": {
+    "code": "4548-4"
+  },
+  "display": "Hematocrit [Volume Fraction] of Blood",
+  "property": "Frac",
+  "system": "Blood",
+  "method": "Automated"
+}

--- a/tests/fixtures/ingestion/medrxiv.json
+++ b/tests/fixtures/ingestion/medrxiv.json
@@ -1,0 +1,12 @@
+{
+  "results": [
+    {
+      "doi": "10.1101/2024.01.01.123456",
+      "title": "Rapid Lactate Clearance",
+      "abstract": "Patients with lactate clearance...",
+      "date": "2024-01-02",
+      "version": "2",
+      "authors": ["Smith J", "Doe A"]
+    }
+  ]
+}

--- a/tests/fixtures/ingestion/mesh_descriptor.json
+++ b/tests/fixtures/ingestion/mesh_descriptor.json
@@ -1,0 +1,19 @@
+{
+  "descriptor": {
+    "descriptorUI": "D012345",
+    "descriptorName": {"string": "Sepsis"},
+    "conceptList": {
+      "concept": [
+        {
+          "conceptUI": "M123",
+          "termList": {
+            "term": [
+              {"string": "Sepsis"},
+              {"string": "Septicemia"}
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/ingestion/nice_guideline.json
+++ b/tests/fixtures/ingestion/nice_guideline.json
@@ -1,0 +1,7 @@
+{
+  "uid": "CG123",
+  "title": "Sepsis in adults",
+  "summary": "This guideline covers...",
+  "url": "https://www.nice.org.uk/guidance/cg123",
+  "licence": "OpenGov"
+}

--- a/tests/fixtures/ingestion/openfda_faers.json
+++ b/tests/fixtures/ingestion/openfda_faers.json
@@ -1,0 +1,18 @@
+{
+  "results": [
+    {
+      "safetyreportid": "R1",
+      "receivedate": "20240101",
+      "patient": {
+        "reaction": [
+          {"reactionmeddrapt": "Headache"}
+        ]
+      },
+      "openfda": {
+        "product_ndc": ["12345-678"],
+        "substance_name": ["DrugX"],
+        "rxcui": ["1234"]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/ingestion/openfda_udi.json
+++ b/tests/fixtures/ingestion/openfda_udi.json
@@ -1,0 +1,14 @@
+{
+  "results": [
+    {
+      "udi_di": "00380740000011",
+      "device_name": "DeviceX",
+      "device_class": "2",
+      "openfda": {
+        "device_name": ["DeviceX"],
+        "fein": ["123456789"],
+        "medical_specialty_description": ["Cardiovascular"]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/ingestion/openprescribing.json
+++ b/tests/fixtures/ingestion/openprescribing.json
@@ -1,0 +1,8 @@
+[
+  {
+    "row_id": "org-1",
+    "chem_name": "DrugX",
+    "items": 120,
+    "actual_cost": 450.75
+  }
+]

--- a/tests/fixtures/ingestion/pmc_record.xml
+++ b/tests/fixtures/ingestion/pmc_record.xml
@@ -1,0 +1,10 @@
+<record>
+  <header>
+    <identifier>oai:pubmedcentral.nih.gov:PMC1234567</identifier>
+    <datestamp>2024-01-15</datestamp>
+  </header>
+  <metadata>
+    <title>Sepsis Management</title>
+    <description>Comprehensive review of sepsis interventions.</description>
+  </metadata>
+</record>

--- a/tests/fixtures/ingestion/pubmed_batch.ndjson
+++ b/tests/fixtures/ingestion/pubmed_batch.ndjson
@@ -1,0 +1,1 @@
+{"term": "lactate"}

--- a/tests/fixtures/ingestion/pubmed_search.json
+++ b/tests/fixtures/ingestion/pubmed_search.json
@@ -1,0 +1,7 @@
+{
+  "esearchresult": {
+    "idlist": ["12345678"],
+    "webenv": "WE123",
+    "querykey": "1"
+  }
+}

--- a/tests/fixtures/ingestion/pubmed_summary.json
+++ b/tests/fixtures/ingestion/pubmed_summary.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "uids": ["12345678"],
+    "12345678": {
+      "uid": "12345678",
+      "title": "Lactate Guided Therapy",
+      "elocationid": "Lactate normalization in sepsis",
+      "pubdate": "2024 Jan",
+      "fulljournalname": "Critical Care",
+      "sortpubdate": "2024/01/01"
+    }
+  }
+}

--- a/tests/fixtures/ingestion/rxnav_properties.json
+++ b/tests/fixtures/ingestion/rxnav_properties.json
@@ -1,0 +1,9 @@
+{
+  "properties": {
+    "rxcui": "1234",
+    "name": "DrugX",
+    "synonym": "DrugX Syn",
+    "tty": "IN",
+    "ndc": "12345-678"
+  }
+}

--- a/tests/fixtures/ingestion/snomed_lookup.json
+++ b/tests/fixtures/ingestion/snomed_lookup.json
@@ -1,0 +1,10 @@
+{
+  "display": "Diabetes mellitus",
+  "code": "44054006",
+  "designation": [
+    {"value": "Diabetes"}
+  ],
+  "property": [
+    {"code": "inactive", "valueBoolean": false}
+  ]
+}

--- a/tests/fixtures/ingestion/umls_cui.json
+++ b/tests/fixtures/ingestion/umls_cui.json
@@ -1,0 +1,8 @@
+{
+  "result": {
+    "ui": "C1234567",
+    "name": "Sepsis",
+    "synonyms": ["Septicemia"],
+    "definition": "A serious medical condition"
+  }
+}

--- a/tests/fixtures/ingestion/uspstf_stub.json
+++ b/tests/fixtures/ingestion/uspstf_stub.json
@@ -1,0 +1,6 @@
+{
+  "id": "USPSTF-1",
+  "title": "Blood Pressure Screening",
+  "status": "Active",
+  "url": "https://www.uspreventiveservicestaskforce.org/uspstf/recommendation"
+}

--- a/tests/fixtures/ingestion/who_gho.json
+++ b/tests/fixtures/ingestion/who_gho.json
@@ -1,0 +1,10 @@
+{
+  "value": [
+    {
+      "Indicator": "Life expectancy",
+      "Value": "72.3",
+      "SpatialDim": "USA",
+      "TimeDim": "2022"
+    }
+  ]
+}

--- a/tests/ingestion/test_adapters.py
+++ b/tests/ingestion/test_adapters.py
@@ -1,0 +1,167 @@
+import asyncio
+import json
+from pathlib import Path
+
+from Medical_KG.ingestion.adapters.base import AdapterContext
+from Medical_KG.ingestion.adapters.clinical import (
+    AccessGudidAdapter,
+    ClinicalTrialsGovAdapter,
+    OpenFdaAdapter,
+    RxNormAdapter,
+)
+from Medical_KG.ingestion.adapters.guidelines import (
+    CdcSocrataAdapter,
+    NiceGuidelineAdapter,
+)
+from Medical_KG.ingestion.adapters.literature import MedRxivAdapter, PmcAdapter, PubMedAdapter
+from Medical_KG.ingestion.adapters.terminology import Icd11Adapter, LoincAdapter, MeSHAdapter, SnomedAdapter, UMLSAdapter
+from Medical_KG.ingestion.http_client import AsyncHttpClient
+from Medical_KG.ingestion.ledger import IngestionLedger
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def test_pubmed_adapter_parses_fixture(monkeypatch, tmp_path: Path) -> None:
+    ledger = IngestionLedger(tmp_path / "ledger.jsonl")
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    adapter = PubMedAdapter(context, client, api_key=None)
+
+    async def fake_fetch_json(url: str, *, params: dict | None = None, headers: dict | None = None) -> dict:
+        if "esearch" in url:
+            return json.loads(Path("tests/fixtures/ingestion/pubmed_search.json").read_text())
+        return json.loads(Path("tests/fixtures/ingestion/pubmed_summary.json").read_text())
+
+    monkeypatch.setattr(adapter, "fetch_json", fake_fetch_json)
+
+    async def _exec() -> None:
+        results = await adapter.run(term="lactate")
+        assert len(results) == 1
+        assert results[0].document.metadata["title"].startswith("Lactate")
+        await client.aclose()
+
+    _run(_exec())
+
+
+def test_clinicaltrials_adapter_validates_nct(tmp_path: Path) -> None:
+    ledger = IngestionLedger(tmp_path / "ledger.jsonl")
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    payload = json.loads(Path("tests/fixtures/ingestion/ctgov_study.json").read_text())
+    adapter = ClinicalTrialsGovAdapter(context, client, bootstrap_records=[payload])
+
+    async def _exec() -> None:
+        results = await adapter.run()
+        assert results[0].document.metadata["record_version"] == "2024-01-01"
+        await client.aclose()
+
+    _run(_exec())
+
+
+def test_openfda_adapter_handles_identifier(tmp_path: Path) -> None:
+    ledger = IngestionLedger(tmp_path / "ledger.jsonl")
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    payload = json.loads(Path("tests/fixtures/ingestion/openfda_faers.json").read_text())["results"][0]
+    adapter = OpenFdaAdapter(context, client, bootstrap_records=[payload])
+
+    async def _exec() -> None:
+        results = await adapter.run(resource="drug/event")
+        assert results[0].document.metadata["identifier"] == "R1"
+        await client.aclose()
+
+    _run(_exec())
+
+
+def test_terminology_adapters(tmp_path: Path) -> None:
+    ledger = IngestionLedger(tmp_path / "ledger.jsonl")
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    mesh_payload = json.loads(Path("tests/fixtures/ingestion/mesh_descriptor.json").read_text())
+    umls_payload = json.loads(Path("tests/fixtures/ingestion/umls_cui.json").read_text())
+    loinc_payload = json.loads(Path("tests/fixtures/ingestion/loinc_lookup.json").read_text())
+    icd_payload = json.loads(Path("tests/fixtures/ingestion/icd11_code.json").read_text())
+    snomed_payload = json.loads(Path("tests/fixtures/ingestion/snomed_lookup.json").read_text())
+
+    async def _exec() -> None:
+        mesh_result = await MeSHAdapter(context, client, bootstrap_records=[mesh_payload]).run(descriptor_id="D012345")
+        umls_result = await UMLSAdapter(context, client, bootstrap_records=[umls_payload]).run(cui="C1234567")
+        loinc_result = await LoincAdapter(context, client, bootstrap_records=[loinc_payload]).run(code="4548-4")
+        icd_result = await Icd11Adapter(context, client, bootstrap_records=[icd_payload]).run(code="1A00")
+        snomed_result = await SnomedAdapter(context, client, bootstrap_records=[snomed_payload]).run(code="44054006")
+        assert mesh_result[0].document.metadata["descriptor_id"] == "D012345"
+        assert umls_result[0].document.metadata["cui"] == "C1234567"
+        assert loinc_result[0].document.metadata["code"] == "4548-4"
+        assert icd_result[0].document.metadata["code"] == "1A00"
+        assert snomed_result[0].document.metadata["code"] == "44054006"
+        await client.aclose()
+
+    _run(_exec())
+
+
+def test_guideline_adapters(tmp_path: Path) -> None:
+    ledger = IngestionLedger(tmp_path / "ledger.jsonl")
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    nice_payload = json.loads(Path("tests/fixtures/ingestion/nice_guideline.json").read_text())
+    cdc_payload = json.loads(Path("tests/fixtures/ingestion/cdc_socrata.json").read_text())
+    adapter_nice = NiceGuidelineAdapter(context, client, bootstrap_records=[nice_payload])
+    adapter_cdc = CdcSocrataAdapter(context, client, bootstrap_records=cdc_payload)
+
+    async def _exec() -> None:
+        nice_result = await adapter_nice.run()
+        cdc_result = await adapter_cdc.run(dataset="abc")
+        assert nice_result[0].document.metadata["uid"] == "CG123"
+        assert cdc_result[0].document.metadata["identifier"].startswith("CA-2023")
+        await client.aclose()
+
+    _run(_exec())
+
+
+def test_accessgudid_validation(tmp_path: Path) -> None:
+    ledger = IngestionLedger(tmp_path / "ledger.jsonl")
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    payload = json.loads(Path("tests/fixtures/ingestion/accessgudid.json").read_text())
+    adapter = AccessGudidAdapter(context, client, bootstrap_records=[payload])
+
+    async def _exec() -> None:
+        results = await adapter.run(udi_di="00380740000011")
+        assert results[0].document.metadata["udi_di"] == "00380740000011"
+        await client.aclose()
+
+    _run(_exec())
+
+
+def test_literature_adapters(tmp_path: Path) -> None:
+    ledger = IngestionLedger(tmp_path / "ledger.jsonl")
+    context = AdapterContext(ledger=ledger)
+    client = AsyncHttpClient()
+    pmc_xml = Path("tests/fixtures/ingestion/pmc_record.xml").read_text()
+    medrxiv_payload = json.loads(Path("tests/fixtures/ingestion/medrxiv.json").read_text())
+    pmc_adapter = PmcAdapter(context, client)
+    medrxiv_adapter = MedRxivAdapter(context, client)
+
+    async def fake_fetch_text(*_, **__):
+        return f"<ListRecords>{pmc_xml}</ListRecords>"
+
+    async def fake_fetch_json(*_, **__):
+        return medrxiv_payload
+
+    pmc_adapter.fetch_text = fake_fetch_text  # type: ignore[assignment]
+    medrxiv_adapter.fetch_json = fake_fetch_json  # type: ignore[assignment]
+
+    async def _exec() -> None:
+        pmc_results = await pmc_adapter.run(set_spec="pmc")
+        medrxiv_results = await medrxiv_adapter.run()
+        assert pmc_results[0].document.metadata["datestamp"] == "2024-01-15"
+        assert medrxiv_results[0].document.metadata["title"].startswith("Rapid")
+        await client.aclose()
+
+    _run(_exec())

--- a/tests/ingestion/test_ingest_cli.py
+++ b/tests/ingestion/test_ingest_cli.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+from Medical_KG.cli import build_parser
+
+
+def test_ingest_cli_batch(tmp_path: Path, monkeypatch) -> None:
+    batch = tmp_path / "batch.ndjson"
+    batch.write_text(json.dumps({"term": "lactate"}))
+    ledger = tmp_path / "ledger.jsonl"
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "ingest",
+        "pubmed",
+        "--batch",
+        str(batch),
+        "--auto",
+        "--ledger",
+        str(ledger),
+    ])
+
+    class DummyAdapter:
+        async def run(self, **kwargs):
+            return []
+
+    class DummyClient:
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr("Medical_KG.cli.get_adapter", lambda *args, **kwargs: DummyAdapter())
+    monkeypatch.setattr("Medical_KG.cli.AsyncHttpClient", lambda: DummyClient())
+    result = args.func(args)
+    assert result == 0

--- a/tests/ir/test_normalizer.py
+++ b/tests/ir/test_normalizer.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from Medical_KG.ir.builder import ClinicalTrialsBuilder
+from Medical_KG.ir.models import Block
+from Medical_KG.ir.normalizer import TextNormalizer
+from Medical_KG.ir.storage import IrStorage
+from Medical_KG.ir.validator import IRValidator, ValidationError
+
+
+def test_text_normalization_handles_dehyphenation() -> None:
+    normalizer = TextNormalizer(dictionary={"treatment"})
+    result = normalizer.normalize("treat-\nment improves outcomes\n\nNew paragraph")
+    assert "treatment" in result.text
+    assert result.language == "en"
+
+
+def test_clinical_trials_builder_creates_blocks(tmp_path: Path) -> None:
+    builder = ClinicalTrialsBuilder()
+    study = {
+        "title": "Trial Title",
+        "status": "Completed",
+        "eligibility": "Adults with sepsis",
+    }
+    document = builder.build_from_study(doc_id="study#1", uri="https://clinicaltrials.gov/study#1", study=study)
+    assert any(isinstance(block, Block) and block.section == "eligibility" for block in document.blocks)
+    validator = IRValidator()
+    validator.validate_document(document)
+    storage = IrStorage(tmp_path)
+    path = storage.write(document)
+    assert path.exists()
+
+
+def test_validator_rejects_bad_offsets() -> None:
+    builder = ClinicalTrialsBuilder()
+    study = {"title": "Title", "status": "Active", "eligibility": "Patients"}
+    document = builder.build_from_study(doc_id="study#2", uri="uri", study=study)
+    document.blocks[0].start = 10
+    with pytest.raises(ValidationError):
+        IRValidator().validate_document(document)

--- a/tests/kg/test_schema.py
+++ b/tests/kg/test_schema.py
@@ -1,0 +1,47 @@
+import pytest
+
+from Medical_KG.kg.schema import CDKOSchema
+from Medical_KG.kg.validators import KgValidationError, KgValidator
+from Medical_KG.kg.writer import KnowledgeGraphWriter
+
+
+def test_schema_contains_expected_constraints() -> None:
+    schema = CDKOSchema.default()
+    statements = schema.as_statements()
+    assert any("doc_uri_unique" in stmt for stmt in statements["constraints"])
+    assert any("chunk_qwen_idx" in stmt for stmt in statements["indexes"])
+
+
+def test_writer_generates_cypher() -> None:
+    writer = KnowledgeGraphWriter()
+    writer.write_document({
+        "id": "doc-1",
+        "source": "clinicaltrials",
+        "uri": "https://example.com",
+        "title": "Sample",
+        "language": "en",
+        "publication_date": "2024-01-01",
+        "meta": {},
+    })
+    writer.write_chunk({
+        "id": "chunk-1",
+        "text": "Example",
+        "section": "introduction",
+        "start": 0,
+        "end": 7,
+        "token_count": 2,
+        "intent": "evidence",
+        "path": "doc-1#0",
+    })
+    writer.write_relationship("HAS_CHUNK", "doc-1", "chunk-1", {"index": 0})
+    statements = list(writer.statements)
+    assert statements[0].parameters["id"] == "doc-1"
+    assert "MERGE" in statements[-1].cypher
+
+
+def test_validator_checks_ucum_and_provenance() -> None:
+    validator = KgValidator(ucum_codes={"mg"})
+    with pytest.raises(KgValidationError):
+        validator.validate_node({"label": "Evidence", "unit_ucum": "g", "provenance": []})
+    with pytest.raises(KgValidationError):
+        validator.validate_relationship({"type": "HAS_AE", "count": -1})


### PR DESCRIPTION
## Summary
- add adapter implementations for clinical, regulatory, and terminology sources plus an ingestion CLI entrypoint and registry
- introduce IR normalization models, JSON schemas, builders, validation, and storage utilities for downstream processing
- define the Neo4j schema/writer utilities with SHACL-like validation and FHIR exporters, backed by targeted unit tests and fixtures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68dea6cab554832f917a2358f40f46ac