### PR TITLE
Harden IR validator schema enforcement

### DIFF
--- a/openspec/changes/add-test-coverage/tasks.md
+++ b/openspec/changes/add-test-coverage/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. Test Suite Stabilization
 - [ ] 1.1 Export missing test utilities (e.g., InMemoryBriefingRepository)
-- [ ] 1.2 Bundle schema references locally to avoid external fetches
+- [x] 1.2 Bundle schema references locally to avoid external fetches
 - [ ] 1.3 Mock external dependencies (NCBI, Kafka, OpenSearch, GPUs)
 - [ ] 1.4 Fix flaky assertions & nondeterministic randomness
 - [ ] 1.5 Document required secrets and provide defaults for tests
@@ -14,7 +14,7 @@
 
 ## 3. Unit & Integration Tests
 - [x] 3.1 Briefing service & formatters edge cases
-- [ ] 3.2 IR builder/validator schema validations
+- [x] 3.2 IR builder/validator schema validations
 - [ ] 3.3 Ingestion adapters (clinical, guidelines, literature, terminology)
 - [ ] 3.4 Retrieval service (auth, caching, ranking fallbacks)
 - [ ] 3.5 Security modules (license enforcement, retention policies)

--- a/src/Medical_KG/ir/schemas/document.schema.json
+++ b/src/Medical_KG/ir/schemas/document.schema.json
@@ -39,6 +39,7 @@
         }
       }
     },
+    "created_at": {"type": "string"},
     "provenance": {"type": "object"}
   },
   "additionalProperties": false

--- a/src/Medical_KG/ir/validator.py
+++ b/src/Medical_KG/ir/validator.py
@@ -1,20 +1,9 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
-from typing import Any, Mapping
-
-try:
-    from jsonschema.validators import Draft202012Validator as _Draft202012Validator
-except Exception:  # pragma: no cover - fallback for doc builds
-
-    class _Draft202012Validator:  # minimal stub
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            pass
-
-        def validate(self, instance: Any) -> None:
-            return None
-
+from typing import Mapping
 
 from Medical_KG.ir.models import DocumentIR, ensure_monotonic_spans
 
@@ -24,12 +13,27 @@ class ValidationError(Exception):
 
 
 class IRValidator:
-    def __init__(self) -> None:
-        schema_path = Path(__file__).resolve().parent / "schemas" / "document.v1.schema.json"
-        self.document_validator = _Draft202012Validator(schema=_load_json(schema_path))
+    """Validate :class:`DocumentIR` instances using bundled JSON schemas."""
+
+    def __init__(self, *, schema_dir: Path | None = None) -> None:
+        base_dir = schema_dir or Path(__file__).resolve().parent / "schemas"
+        self._schema_dir = base_dir
+        self._schemas = {
+            "document": self._load_schema(base_dir / "document.schema.json"),
+            "block": self._load_schema(base_dir / "block.schema.json"),
+            "table": self._load_schema(base_dir / "table.schema.json"),
+        }
+        language_pattern = self._schemas["document"]["properties"]["language"].get("pattern", "")
+        self._language_pattern = re.compile(language_pattern) if language_pattern else None
+
+    @property
+    def schema_store(self) -> Mapping[str, Mapping[str, Any]]:
+        """Expose loaded schemas for tests and tooling."""
+
+        return dict(self._schemas)
 
     def _load_schema(self, path: Path) -> Mapping[str, Any]:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
 
     def validate_document(self, document: DocumentIR) -> None:
         payload = document.as_dict()
@@ -37,24 +41,14 @@ class IRValidator:
             raise ValidationError("Document must have a doc_id")
         if not document.uri:
             raise ValidationError("Document must have a uri")
-        try:
-            self.document_validator.validate(payload)
-        except _JsonSchemaError as exc:
-            raise ValidationError(f"Document schema validation failed: {exc.message}") from exc
+
+        self._validate_document_payload(payload)
 
         for block_payload in payload["blocks"]:
-            try:
-                self.block_validator.validate(block_payload)
-            except _JsonSchemaError as exc:
-                raise ValidationError(f"Block validation failed: {exc.message}") from exc
+            self._validate_block_payload(block_payload)
 
         for table_payload in payload["tables"]:
-            try:
-                self.table_validator.validate(table_payload)
-            except _JsonSchemaError as exc:
-                raise ValidationError(f"Table validation failed: {exc.message}") from exc
-            if table_payload["end"] < table_payload["start"]:
-                raise ValidationError("Table span invalid")
+            self._validate_table_payload(table_payload)
 
         try:
             ensure_monotonic_spans(document.blocks)
@@ -62,6 +56,103 @@ class IRValidator:
             raise ValidationError(str(exc)) from exc
         self._validate_offsets(document)
         self._validate_span_map(payload["span_map"])
+
+    def _validate_document_payload(self, payload: Mapping[str, Any]) -> None:
+        schema = self._schemas["document"]
+        required = schema.get("required", [])
+        missing = [field for field in required if field not in payload]
+        if missing:
+            raise ValidationError(f"Document missing required fields: {', '.join(missing)}")
+
+        for field in ("doc_id", "source", "uri", "language", "text", "raw_text"):
+            value = payload.get(field)
+            if not isinstance(value, str):
+                raise ValidationError(f"Document field '{field}' must be a string")
+            if field in {"doc_id", "source", "uri"} and not value.strip():
+                raise ValidationError(f"Document field '{field}' cannot be empty")
+
+        if self._language_pattern and not self._language_pattern.fullmatch(payload["language"]):
+            raise ValidationError("Document language must be a two-letter code")
+
+        if not isinstance(payload.get("blocks"), list):
+            raise ValidationError("Document blocks must be an array")
+        if not isinstance(payload.get("tables"), list):
+            raise ValidationError("Document tables must be an array")
+        if not isinstance(payload.get("span_map"), list):
+            raise ValidationError("Document span_map must be an array")
+
+        provenance = payload.get("provenance", {})
+        if provenance is not None and not isinstance(provenance, dict):
+            raise ValidationError("Document provenance must be an object")
+
+        allowed_keys = set(schema.get("properties", {}).keys()) | {"created_at"}
+        extras = set(payload.keys()) - allowed_keys
+        if extras:
+            raise ValidationError(f"Document contains unsupported fields: {', '.join(sorted(extras))}")
+
+    def _validate_block_payload(self, block: Mapping[str, Any]) -> None:
+        schema = self._schemas["block"]
+        required = schema.get("required", [])
+        missing = [field for field in required if field not in block]
+        if missing:
+            raise ValidationError(f"Block missing required fields: {', '.join(missing)}")
+
+        allowed_keys = set(schema.get("properties", {}).keys())
+        extras = set(block.keys()) - allowed_keys
+        if extras:
+            raise ValidationError(f"Block contains unsupported fields: {', '.join(sorted(extras))}")
+
+        if not isinstance(block["type"], str) or not block["type"]:
+            raise ValidationError("Block type must be a non-empty string")
+        if not isinstance(block["text"], str):
+            raise ValidationError("Block text must be a string")
+        for field in ("start", "end"):
+            value = block[field]
+            if not isinstance(value, int) or value < 0:
+                raise ValidationError(f"Block {field} must be a non-negative integer")
+
+        section = block.get("section")
+        if section is not None and not isinstance(section, str):
+            raise ValidationError("Block section must be a string or None")
+
+        meta = block.get("meta", {})
+        if not isinstance(meta, dict):
+            raise ValidationError("Block meta must be an object")
+
+    def _validate_table_payload(self, table: Mapping[str, Any]) -> None:
+        schema = self._schemas["table"]
+        required = schema.get("required", [])
+        missing = [field for field in required if field not in table]
+        if missing:
+            raise ValidationError(f"Table missing required fields: {', '.join(missing)}")
+
+        allowed_keys = set(schema.get("properties", {}).keys())
+        extras = set(table.keys()) - allowed_keys
+        if extras:
+            raise ValidationError(f"Table contains unsupported fields: {', '.join(sorted(extras))}")
+
+        if not isinstance(table["caption"], str):
+            raise ValidationError("Table caption must be a string")
+        if not isinstance(table.get("headers"), list):
+            raise ValidationError("Table headers must be an array")
+        if not all(isinstance(header, str) for header in table["headers"]):
+            raise ValidationError("Table headers must be strings")
+        if not isinstance(table.get("rows"), list):
+            raise ValidationError("Table rows must be an array")
+        for row in table["rows"]:
+            if not isinstance(row, list) or not all(isinstance(cell, str) for cell in row):
+                raise ValidationError("Table rows must be arrays of strings")
+
+        for field in ("start", "end"):
+            value = table[field]
+            if not isinstance(value, int) or value < 0:
+                raise ValidationError(f"Table {field} must be a non-negative integer")
+        if table["end"] < table["start"]:
+            raise ValidationError("Table span invalid")
+
+        meta = table.get("meta", {})
+        if not isinstance(meta, dict):
+            raise ValidationError("Table meta must be an object")
 
     def _validate_offsets(self, document: DocumentIR) -> None:
         text_length = len(document.text)

--- a/tests/ir/test_validator.py
+++ b/tests/ir/test_validator.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import pytest
+
+from Medical_KG.ir.models import Block, DocumentIR, SpanMap, Table
+from Medical_KG.ir.validator import IRValidator, ValidationError
+
+
+def _make_document() -> DocumentIR:
+    document = DocumentIR(
+        doc_id="doc-1",
+        source="unit-test",
+        uri="https://example/doc-1",
+        language="en",
+        text="Heading\n\nContent",
+        raw_text="Heading\n\nContent",
+    )
+    document.add_block(
+        Block(type="heading", text="Heading", start=0, end=7, section="title", meta={})
+    )
+    document.add_block(
+        Block(type="paragraph", text="Content", start=9, end=16, section="body", meta={})
+    )
+    document.add_table(
+        Table(caption="Table 1", headers=["h1"], rows=[["r1"]], start=16, end=23, meta={})
+    )
+    document.span_map = SpanMap()
+    document.span_map.add(0, len(document.raw_text), 0, len(document.text), "normalize", page=1)
+    document.provenance["source"] = "fixture"
+    return document
+
+
+def test_ir_validator_accepts_valid_document() -> None:
+    validator = IRValidator()
+    validator.validate_document(_make_document())
+    assert "document" in validator.schema_store
+
+
+def test_ir_validator_requires_doc_id() -> None:
+    document = _make_document()
+    document.doc_id = ""
+    with pytest.raises(ValidationError, match="doc_id"):
+        IRValidator().validate_document(document)
+
+
+def test_ir_validator_requires_uri() -> None:
+    document = _make_document()
+    document.uri = ""
+    with pytest.raises(ValidationError, match="uri"):
+        IRValidator().validate_document(document)
+
+
+def test_ir_validator_enforces_language_pattern() -> None:
+    document = _make_document()
+    document.language = "english"
+    with pytest.raises(ValidationError, match="language"):
+        IRValidator().validate_document(document)
+
+
+def test_ir_validator_rejects_extra_document_fields() -> None:
+    validator = IRValidator()
+    payload = _make_document().as_dict()
+    payload["unexpected"] = "value"
+    with pytest.raises(ValidationError, match="unsupported"):
+        validator._validate_document_payload(payload)  # type: ignore[arg-type]
+
+
+def test_ir_validator_rejects_invalid_block_payload() -> None:
+    validator = IRValidator()
+    block_payload = {
+        "type": "heading",
+        "text": "Title",
+        "start": 0,
+        "end": 5,
+        "meta": {},
+        "section": None,
+        "extra": True,
+    }
+    with pytest.raises(ValidationError, match="unsupported"):
+        validator._validate_block_payload(block_payload)
+
+
+def test_ir_validator_rejects_block_meta_type() -> None:
+    validator = IRValidator()
+    block_payload = {
+        "type": "heading",
+        "text": "Title",
+        "start": 0,
+        "end": 5,
+        "meta": "invalid",
+    }
+    with pytest.raises(ValidationError, match="meta"):
+        validator._validate_block_payload(block_payload)
+
+
+def test_ir_validator_rejects_table_payload_errors() -> None:
+    validator = IRValidator()
+    table_payload = {
+        "caption": "T",
+        "headers": ["h"],
+        "rows": [["r"]],
+        "start": 2,
+        "end": 1,
+    }
+    with pytest.raises(ValidationError, match="span"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_table_requires_string_rows() -> None:
+    validator = IRValidator()
+    table_payload = {
+        "caption": "T",
+        "headers": ["h"],
+        "rows": [[1]],
+        "start": 0,
+        "end": 0,
+        "meta": {},
+    }
+    with pytest.raises(ValidationError, match="rows"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_rejects_table_meta_type() -> None:
+    validator = IRValidator()
+    table_payload = {
+        "caption": "T",
+        "headers": ["h"],
+        "rows": [["r"]],
+        "start": 0,
+        "end": 0,
+        "meta": "invalid",
+    }
+    with pytest.raises(ValidationError, match="meta"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_rejects_span_map_page_floor() -> None:
+    document = _make_document()
+    end = len(document.text)
+    document.span_map.add(end, end + 1, end, end + 1, "normalize", page=0)
+    with pytest.raises(ValidationError, match="page numbers"):
+        IRValidator().validate_document(document)
+
+
+def test_ir_validator_rejects_block_offset_overflow() -> None:
+    document = _make_document()
+    overflow = len(document.text) + 5
+    document.blocks[0].end = overflow
+    document.blocks[1].start = overflow
+    document.blocks[1].end = overflow + 1
+    with pytest.raises(ValidationError, match="exceeds"):
+        IRValidator().validate_document(document)
+
+
+def test_ir_validator_document_missing_required_field() -> None:
+    validator = IRValidator()
+    payload = _make_document().as_dict()
+    payload.pop("doc_id")
+    with pytest.raises(ValidationError, match="missing required"):
+        validator._validate_document_payload(payload)  # type: ignore[arg-type]
+
+
+def test_ir_validator_document_field_type() -> None:
+    validator = IRValidator()
+    payload = _make_document().as_dict()
+    payload["doc_id"] = 123  # type: ignore[assignment]
+    with pytest.raises(ValidationError, match="must be a string"):
+        validator._validate_document_payload(payload)  # type: ignore[arg-type]
+
+
+def test_ir_validator_document_collections_must_be_lists() -> None:
+    validator = IRValidator()
+    payload = _make_document().as_dict()
+    payload["blocks"] = "invalid"
+    with pytest.raises(ValidationError, match="blocks must be an array"):
+        validator._validate_document_payload(payload)  # type: ignore[arg-type]
+    payload["blocks"] = []
+    payload["tables"] = "invalid"
+    with pytest.raises(ValidationError, match="tables must be an array"):
+        validator._validate_document_payload(payload)  # type: ignore[arg-type]
+    payload["tables"] = []
+    payload["span_map"] = "invalid"
+    with pytest.raises(ValidationError, match="span_map must be an array"):
+        validator._validate_document_payload(payload)  # type: ignore[arg-type]
+
+
+def test_ir_validator_document_provenance_type() -> None:
+    validator = IRValidator()
+    payload = _make_document().as_dict()
+    payload["provenance"] = "invalid"
+    with pytest.raises(ValidationError, match="provenance"):
+        validator._validate_document_payload(payload)  # type: ignore[arg-type]
+
+
+def test_ir_validator_block_missing_fields() -> None:
+    validator = IRValidator()
+    block_payload = {"type": "heading", "start": 0, "end": 5}
+    with pytest.raises(ValidationError, match="missing required"):
+        validator._validate_block_payload(block_payload)
+
+
+def test_ir_validator_block_type_and_text_validation() -> None:
+    validator = IRValidator()
+    block_payload = {
+        "type": "",
+        "text": "Title",
+        "start": 0,
+        "end": 1,
+        "meta": {},
+    }
+    with pytest.raises(ValidationError, match="non-empty"):
+        validator._validate_block_payload(block_payload)
+    block_payload["type"] = "heading"
+    block_payload["text"] = 123  # type: ignore[assignment]
+    with pytest.raises(ValidationError, match="text must be a string"):
+        validator._validate_block_payload(block_payload)
+
+
+def test_ir_validator_block_offset_types() -> None:
+    validator = IRValidator()
+    block_payload = {
+        "type": "heading",
+        "text": "Title",
+        "start": -1,
+        "end": 1,
+        "meta": {},
+    }
+    with pytest.raises(ValidationError, match="start must be a non-negative integer"):
+        validator._validate_block_payload(block_payload)
+    block_payload["start"] = 0
+    block_payload["end"] = "1"  # type: ignore[assignment]
+    with pytest.raises(ValidationError, match="end must be a non-negative integer"):
+        validator._validate_block_payload(block_payload)
+
+
+def test_ir_validator_block_section_type_guard() -> None:
+    validator = IRValidator()
+    block_payload = {
+        "type": "heading",
+        "text": "Title",
+        "start": 0,
+        "end": 1,
+        "meta": {},
+        "section": 123,
+    }
+    with pytest.raises(ValidationError, match="section must be a string"):
+        validator._validate_block_payload(block_payload)
+
+
+def test_ir_validator_offsets_section_guard() -> None:
+    document = _make_document()
+    document.blocks[0].section = 123  # type: ignore[assignment]
+    with pytest.raises(ValidationError, match="section must be a string"):
+        IRValidator()._validate_offsets(document)
+
+
+def test_ir_validator_table_missing_fields() -> None:
+    validator = IRValidator()
+    table_payload = {"caption": "T", "headers": ["h"], "start": 0, "end": 0}
+    with pytest.raises(ValidationError, match="missing required"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_table_extra_fields() -> None:
+    validator = IRValidator()
+    table_payload = {
+        "caption": "T",
+        "headers": ["h"],
+        "rows": [["r"]],
+        "start": 0,
+        "end": 0,
+        "meta": {},
+        "extra": True,
+    }
+    with pytest.raises(ValidationError, match="unsupported"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_table_header_and_row_types() -> None:
+    validator = IRValidator()
+    table_payload = {
+        "caption": 1,
+        "headers": ["h"],
+        "rows": [["r"]],
+        "start": 0,
+        "end": 0,
+        "meta": {},
+    }
+    with pytest.raises(ValidationError, match="caption"):
+        validator._validate_table_payload(table_payload)
+    table_payload["caption"] = "T"
+    table_payload["headers"] = "h"  # type: ignore[assignment]
+    with pytest.raises(ValidationError, match="headers must be an array"):
+        validator._validate_table_payload(table_payload)
+    table_payload["headers"] = [123]  # type: ignore[list-item]
+    with pytest.raises(ValidationError, match="headers must be strings"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_table_row_collection_types() -> None:
+    validator = IRValidator()
+    table_payload = {
+        "caption": "T",
+        "headers": ["h"],
+        "rows": "invalid",
+        "start": 0,
+        "end": 0,
+        "meta": {},
+    }
+    with pytest.raises(ValidationError, match="rows must be an array"):
+        validator._validate_table_payload(table_payload)
+    table_payload["rows"] = [[1]]
+    with pytest.raises(ValidationError, match="rows must be arrays of strings"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_table_offset_types() -> None:
+    validator = IRValidator()
+    table_payload = {
+        "caption": "T",
+        "headers": ["h"],
+        "rows": [["r"]],
+        "start": -1,
+        "end": 0,
+        "meta": {},
+    }
+    with pytest.raises(ValidationError, match="start must be a non-negative integer"):
+        validator._validate_table_payload(table_payload)
+    table_payload["start"] = 0
+    table_payload["end"] = "0"  # type: ignore[assignment]
+    with pytest.raises(ValidationError, match="end must be a non-negative integer"):
+        validator._validate_table_payload(table_payload)
+
+
+def test_ir_validator_span_map_monotonicity() -> None:
+    validator = IRValidator()
+    span_map = [
+        {"canonical_start": 0, "canonical_end": 5},
+        {"canonical_start": 3, "canonical_end": 7},
+    ]
+    with pytest.raises(ValidationError, match="monotonic"):
+        validator._validate_span_map(span_map)  # type: ignore[arg-type]
+
+


### PR DESCRIPTION
## Summary
- replace the IR validator stub with offline schema validation that loads bundled JSON definitions and enforces field-level constraints
- align the document schema with the runtime payload by declaring the created_at property and exposing the schema store for tooling
- add exhaustive IR validator tests to cover success paths and schema failures, and mark the OpenSpec tasks as completed

## Testing
- DISABLE_COVERAGE_TRACE=1 pytest tests/ir/test_validator.py -q


------
https://chatgpt.com/codex/tasks/task_e_68df8908abd8832f887f7700faae185b