### PR TITLE
Refactor ingestion adapters to avoid casts

### DIFF
--- a/openspec/changes/eliminate-ingestion-adapter-casts/tasks.md
+++ b/openspec/changes/eliminate-ingestion-adapter-casts/tasks.md
@@ -2,28 +2,28 @@
 
 ## 1. Narrowing Helper Functions
 
-- [ ] 1.1 Implement `narrow_to_mapping(value: JSONValue, context: str) -> JSONMapping` in types.py
-- [ ] 1.2 Implement `narrow_to_sequence(value: JSONValue, context: str) -> JSONSequence` in types.py
-- [ ] 1.3 Add unit tests for narrowing functions (valid and invalid inputs)
-- [ ] 1.4 Document when to use narrowing vs ensure_json_* helpers
+- [x] 1.1 Implement `narrow_to_mapping(value: JSONValue, context: str) -> JSONMapping` in types.py
+- [x] 1.2 Implement `narrow_to_sequence(value: JSONValue, context: str) -> JSONSequence` in types.py
+- [x] 1.3 Add unit tests for narrowing functions (valid and invalid inputs)
+- [x] 1.4 Document when to use narrowing vs ensure_json_* helpers
 
 ## 2. Clinical Adapters Cast Elimination
 
-- [ ] 2.1 Audit all 20 casts in `ClinicalTrialsGovAdapter.parse()` and categorize by pattern
-- [ ] 2.2 Replace `cast(JSONValue, protocol.get(...))` with typed intermediate variables
-- [ ] 2.3 Replace `cast(JSONValue, raw.get("derivedSection", {}))` patterns with narrowing
-- [ ] 2.4 Update `OpenFdaAdapter.fetch()` line 272 to properly type records without cast
-- [ ] 2.5 Review remaining casts in clinical.py and eliminate where possible
+- [x] 2.1 Audit all 20 casts in `ClinicalTrialsGovAdapter.parse()` and categorize by pattern
+- [x] 2.2 Replace `cast(JSONValue, protocol.get(...))` with typed intermediate variables
+- [x] 2.3 Replace `cast(JSONValue, raw.get("derivedSection", {}))` patterns with narrowing
+- [x] 2.4 Update `OpenFdaAdapter.fetch()` line 272 to properly type records without cast
+- [x] 2.5 Review remaining casts in clinical.py and eliminate where possible
 
 ## 3. Guidelines Adapters Cast Elimination
 
-- [ ] 3.1 Review 3 casts in guidelines.py and replace with narrowing functions
-- [ ] 3.2 Ensure CdcSocrataAdapter and related adapters use typed access patterns
+- [x] 3.1 Review 3 casts in guidelines.py and replace with narrowing functions
+- [x] 3.2 Ensure CdcSocrataAdapter and related adapters use typed access patterns
 
 ## 4. Validation & Documentation
 
-- [ ] 4.1 Run `mypy --strict` on ingestion module and confirm cast reduction
-- [ ] 4.2 Grep for `cast\(` in ingestion/* and verify count ≤5
-- [ ] 4.3 Document remaining casts with inline comments explaining necessity
-- [ ] 4.4 Update module docstrings explaining narrowing vs casting guidelines
-- [ ] 4.5 Run full test suite to ensure no regressions
+- [x] 4.1 Run `mypy --strict` on ingestion module and confirm cast reduction
+- [x] 4.2 Grep for `cast\(` in ingestion/* and verify count ≤5
+- [x] 4.3 Document remaining casts with inline comments explaining necessity
+- [x] 4.4 Update module docstrings explaining narrowing vs casting guidelines
+- [x] 4.5 Run full test suite to ensure no regressions *(fails in this environment: missing fastapi, pdfminer, pydantic, bs4, pytest_asyncio, hypothesis)*

--- a/src/Medical_KG/ingestion/adapters/clinical.py
+++ b/src/Medical_KG/ingestion/adapters/clinical.py
@@ -4,7 +4,7 @@ import json
 import re
 import xml.etree.ElementTree as ET
 from collections.abc import AsyncIterator, Iterable
-from typing import Mapping, MutableMapping, Sequence
+from typing import Mapping, Sequence
 
 from Medical_KG.ingestion.adapters.base import AdapterContext
 from Medical_KG.ingestion.adapters.http import HttpAdapter
@@ -21,6 +21,7 @@ from Medical_KG.ingestion.types import (
     OpenFdaDocumentPayload,
     RxNormDocumentPayload,
     is_clinical_document_payload,
+    narrow_to_mapping,
 )
 from Medical_KG.ingestion.utils import (
     canonical_json,
@@ -114,11 +115,14 @@ class ClinicalTrialsGovAdapter(HttpAdapter[ClinicalTrialsStudyPayload]):
         summary = normalize_text(str(summary_value)) if isinstance(summary_value, str) else ""
 
         derived_section_value = raw.get("derivedSection")
-        derived_section = (
-            ensure_json_mapping(derived_section_value, context="clinicaltrials derived section")
-            if isinstance(derived_section_value, Mapping)
-            else {}
-        )
+        derived_section: dict[str, JSONValue] = {}
+        if derived_section_value is not None:
+            derived_section = dict(
+                narrow_to_mapping(
+                    derived_section_value,
+                    context="clinicaltrials derived section",
+                )
+            )
         misc_info = ensure_json_mapping(
             derived_section.get("miscInfoModule", {}),
             context="clinicaltrials misc info",

--- a/src/Medical_KG/ingestion/http_client.py
+++ b/src/Medical_KG/ingestion/http_client.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import random
 from collections import deque
 from contextlib import asynccontextmanager
-import importlib.util
 from dataclasses import dataclass
 from time import time
 from typing import AsyncIterator, Generic, Mapping, MutableMapping, TypeVar, cast
@@ -16,7 +16,7 @@ from Medical_KG.compat.httpx import (
     ResponseProtocol,
     create_async_client,
 )
-from Medical_KG.compat.prometheus import Counter, Histogram
+from Medical_KG.ingestion.types import JSONValue
 from Medical_KG.utils.optional_dependencies import (
     CounterProtocol,
     HistogramProtocol,
@@ -25,7 +25,6 @@ from Medical_KG.utils.optional_dependencies import (
     build_histogram,
     get_httpx_module,
 )
-from Medical_KG.ingestion.types import JSONValue
 
 HTTPX: HttpxModule = get_httpx_module()
 
@@ -199,6 +198,7 @@ class AsyncHttpClient:
         headers: Mapping[str, str] | None = None,
     ) -> JsonResponse[JSONValue]:
         response = await self.get(url, params=params, headers=headers)
+        # ``httpx.Response.json`` returns ``Any``; narrow to ``JSONValue`` for callers.
         payload = cast(JSONValue, response.json())
         return JsonResponse(url=url, status_code=response.status_code, data=payload)
 

--- a/tests/ingestion/test_type_guards.py
+++ b/tests/ingestion/test_type_guards.py
@@ -138,6 +138,28 @@ def make_openprescribing_payload() -> types.OpenPrescribingDocumentPayload:
     }
 
 
+def test_narrow_to_mapping_accepts_mapping() -> None:
+    value: types.JSONValue = {"key": "value"}
+    result = types.narrow_to_mapping(value, context="narrow mapping")
+    assert result == value
+
+
+def test_narrow_to_mapping_rejects_non_mapping() -> None:
+    with pytest.raises(TypeError, match="narrow mapping expected a mapping"):
+        types.narrow_to_mapping(["value"], context="narrow mapping")
+
+
+def test_narrow_to_sequence_accepts_sequence() -> None:
+    value: types.JSONValue = ["value", 1]
+    result = types.narrow_to_sequence(value, context="narrow sequence")
+    assert list(result) == ["value", 1]
+
+
+def test_narrow_to_sequence_rejects_string() -> None:
+    with pytest.raises(TypeError, match="narrow sequence expected a sequence"):
+        types.narrow_to_sequence("value", context="narrow sequence")
+
+
 def make_pubmed_payload() -> types.PubMedDocumentPayload:
     return {
         "pmid": "12345678",


### PR DESCRIPTION
## Summary
- add `narrow_to_mapping` and `narrow_to_sequence` helpers plus unit coverage to remove ad-hoc casts from ingestion adapters
- refactor clinical, literature, and terminology adapters to rely on TypedDict-aware narrowing and document the remaining cast boundary cases
- update OpenSpec task checklist after finishing the cast elimination and document remaining cast locations

## Testing
- python -m mypy --strict src/Medical_KG/ingestion
- ruff check src/Medical_KG/ingestion/adapters/clinical.py src/Medical_KG/ingestion/adapters/literature.py src/Medical_KG/ingestion/adapters/terminology.py src/Medical_KG/ingestion/http_client.py src/Medical_KG/ingestion/ledger.py src/Medical_KG/ingestion/types.py tests/ingestion/test_type_guards.py
- pytest -q *(fails: missing fastapi, pdfminer, pydantic, bs4, pytest_asyncio, hypothesis in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e042688438832f8045f1899090ead9