### PR TITLE
fix: harden ingestion cli batch loading

### DIFF
--- a/docs/repo_review.md
+++ b/docs/repo_review.md
@@ -1,0 +1,13 @@
+# Repository Review – February 2025
+
+## Addressed Issue
+- Hardened the ingestion Typer CLI batch loader by importing the missing `json` module and validating each NDJSON row. Malformed JSON or non-object entries now surface as actionable `BadParameter` errors instead of crashing at runtime, and new tests pin the behavior.【F:src/Medical_KG/ingestion/cli.py†L3-L80】【F:tests/ingestion/test_ingestion_cli.py†L1-L155】
+
+## Recommended Improvements
+1. **Defensive dossier formatting** – `BriefingFormatter` assumes every section, item, and citation dictionary contains specific keys (e.g., `section['title']`, `citation['doc_id']`). Missing keys or differently shaped payloads will raise `KeyError`s and break HTML/PDF generation. Guard these lookups with `.get` checks (or dataclass models) and fall back gracefully so formatter output remains robust to partial data.【F:src/Medical_KG/briefing/formatters.py†L25-L118】
+2. **Unify ingestion CLIs** – The legacy `med ingest` command in `Medical_KG.cli` reimplements batching, adapter invocation, and JSON parsing separately from the new Typer-based CLI, still lacking the richer validation we just added. Consolidating both entrypoints on shared helpers (or delegating to `ingestion.cli.ingest`) would prevent future drift and ensure consistent error handling and resume semantics across tooling.【F:src/Medical_KG/cli.py†L224-L315】【F:src/Medical_KG/ingestion/cli.py†L25-L97】
+3. **Modernize Ruff configuration** – The project still uses `extend-select` under `[tool.ruff]`, which emits deprecation warnings with recent Ruff releases. Migrating to the `[tool.ruff.lint]` table keeps the config forward-compatible and removes the recurring warning during lint runs.【F:pyproject.toml†L150-L154】
+4. **Document lint/type overrides** – Large `mypy` ignore blocks (e.g., the blanket `ignore_errors` for `Medical_KG.briefing.*` and `retrieval.*`) make it harder to track real typing debt. Audit these overrides and replace them with targeted fixes or module-level TODO comments so future contributors understand the remaining gaps.【F:pyproject.toml†L164-L195】
+
+## Suggested Follow-Up Tests
+- Extend the Typer CLI test suite with cases for the recommended dossier formatter guards and any future ingestion CLI consolidation to ensure regressions are caught early.【F:tests/ingestion/test_ingestion_cli.py†L1-L155】


### PR DESCRIPTION
## Summary
- import the json module and add NDJSON row validation in the ingestion Typer CLI
- extend the ingestion CLI test suite to cover malformed batch inputs and document broader repo review recommendations

## Testing
- `ruff check src/Medical_KG/ingestion/cli.py tests/ingestion/test_ingestion_cli.py`
- `pytest -q` *(fails: missing optional deps such as fastapi.Header, pdfminer, pydantic, pytest_asyncio, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68e05116383c832fb5068f16ad2bc1ef