### PR TITLE
feat: replace config validation with jsonschema

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,21 @@ This document describes the structure of `config.yaml` and the companion files t
 
 At runtime the loader merges the files in the order above and applies environment variables (highest precedence).
 
+## Schema Validation
+
+All configuration files declare a `$schema` pointer (for example `./config.schema.json#v1.0.0`). The loader resolves `config.schema.json`, verifies it targets JSON Schema Draft 7, and enforces the declared schema version. If a configuration references a different schema version the reload fails with guidance to migrate to the supported release. Update the `$schema` pointer and adjust any renamed fields when the schema version advances.
+
+### Custom Formats
+
+`config.schema.json` registers project-specific formats in addition to the JSON Schema defaults:
+
+| Format | Purpose | Examples |
+| --- | --- | --- |
+| `duration` | Human-friendly durations used by schedulers. | `"5m"`, `"15m"`, `"1h"` |
+| `adapter_name` | Validates ingestion adapters against the registry. | `"pubmed"`, `"pmc"`, `"loinc"` |
+
+Invalid values surface in validation errors with JSON Pointer locations and remediation hints, making it easier to spot typos or unsupported adapters.
+
 ## Section Reference
 
 ### `feature_flags`
@@ -33,6 +48,10 @@ Defines upstream connectors. Every source entry contains:
 ### `chunking`
 
 Profiles with token and coherence controls for document segmentation. `target_tokens` must be greater than 0 and `overlap` must be less than `target_tokens`.
+
+### `pipelines`
+
+Defines runtime orchestration for ingestion and document processing. The `pdf` block configures artifact paths and GPU requirements for the PDF pipeline. The optional `pipelines.scheduled` array registers recurring ingestion jobs; each entry declares an `adapter` (validated against the adapter registry), an execution `interval` using the `duration` format, and an optional `enabled` flag to stage schedules without activating them.
 
 ### `embeddings`
 

--- a/src/Medical_KG/cli.py
+++ b/src/Medical_KG/cli.py
@@ -10,7 +10,12 @@ from pathlib import Path
 from types import TracebackType
 from typing import Protocol, cast
 
-from Medical_KG.config.manager import ConfigError, ConfigManager, ConfigValidator, mask_secrets
+from Medical_KG.config.manager import (
+    ConfigError,
+    ConfigManager,
+    ConfigSchemaValidator,
+    mask_secrets,
+)
 from Medical_KG.config.models import PdfPipelineSettings
 from Medical_KG.ingestion.ledger import IngestionLedger
 from Medical_KG.pdf import (
@@ -79,7 +84,9 @@ def _command_validate(args: argparse.Namespace) -> int:
     try:
         manager = _load_manager(args.config_dir)
         payload = manager.raw_payload()
-        ConfigValidator(manager.base_path / "config.schema.json").validate(payload)
+        ConfigSchemaValidator(manager.base_path / "config.schema.json").validate(
+            payload, source="CLI payload"
+        )
         _ = manager.config
     except ConfigError as exc:
         print(f"Configuration invalid: {exc}")

--- a/src/Medical_KG/config/config-dev.yaml
+++ b/src/Medical_KG/config/config-dev.yaml
@@ -1,4 +1,5 @@
 {
+  "$schema": "./config.schema.json#v1.0.0",
   "feature_flags": {
     "extraction_experimental_enabled": true
   },

--- a/src/Medical_KG/config/config-prod.yaml
+++ b/src/Medical_KG/config/config-prod.yaml
@@ -1,4 +1,5 @@
 {
+  "$schema": "./config.schema.json#v1.0.0",
   "observability": {
     "logging": {
       "level": "warn"

--- a/src/Medical_KG/config/config-staging.yaml
+++ b/src/Medical_KG/config/config-staging.yaml
@@ -1,4 +1,5 @@
 {
+  "$schema": "./config.schema.json#v1.0.0",
   "observability": {
     "logging": {
       "level": "info"

--- a/src/Medical_KG/config/config.schema.json
+++ b/src/Medical_KG/config/config.schema.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Medical KG Configuration",
+  "version": "1.0.0",
   "type": "object",
   "required": [
     "config_version",
@@ -19,6 +20,11 @@
     "entity_linking"
   ],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference",
+      "description": "JSON Schema reference with embedded version information"
+    },
     "config_version": {
       "type": "string",
       "description": "Semantic identifier for the configuration payload"
@@ -618,9 +624,35 @@
           },
           "required": ["ledger_path", "artifact_dir", "require_gpu"],
           "additionalProperties": false
+        },
+        "scheduled": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/pipelineSchedule" },
+          "description": "Optional ingestion jobs with adapter and cadence"
         }
       },
       "required": ["pdf"],
+      "additionalProperties": false
+    },
+    "pipelineSchedule": {
+      "type": "object",
+      "properties": {
+        "adapter": {
+          "type": "string",
+          "format": "adapter_name",
+          "description": "Registered ingestion adapter name"
+        },
+        "interval": {
+          "type": "string",
+          "format": "duration",
+          "description": "Execution cadence (e.g., '15m', '1h')"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the scheduled run is active"
+        }
+      },
+      "required": ["adapter", "interval"],
       "additionalProperties": false
     },
     "entityLinkingConfig": {

--- a/src/Medical_KG/config/config.yaml
+++ b/src/Medical_KG/config/config.yaml
@@ -1,4 +1,5 @@
 {
+  "$schema": "./config.schema.json#v1.0.0",
   "config_version": "1.0.0",
   "feature_flags": {
     "splade_enabled": true,


### PR DESCRIPTION
## Summary
- replace the bespoke configuration validator with a jsonschema-backed ConfigSchemaValidator that adds custom format handling and richer error reporting
- add schema version metadata, new scheduled pipeline schema entries, and propagate $schema references across configuration files
- document schema validation, custom formats, and scheduled pipelines while extending config tests to cover the new behaviour

## Testing
- pytest tests/config/test_config_manager.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0bd5dec6c832fae7c7c1850c3eedf