### PR TITLE
feat: add streaming pipeline events and tests

### DIFF
--- a/openspec/changes/refactor-ingestion-pipeline-streaming/tasks.md
+++ b/openspec/changes/refactor-ingestion-pipeline-streaming/tasks.md
@@ -2,53 +2,53 @@
 
 ## 1. Design Event System
 
-- [ ] 1.1 Define `PipelineEvent` base class with common fields (timestamp, pipeline_id)
-- [ ] 1.2 Define `DocumentStarted` event (doc_id, adapter, parameters)
-- [ ] 1.3 Define `DocumentCompleted` event (document, duration, metadata)
-- [ ] 1.4 Define `DocumentFailed` event (doc_id, error, retry_count, is_retryable)
-- [ ] 1.5 Define `BatchProgress` event (completed_count, failed_count, remaining, eta)
-- [ ] 1.6 Define `AdapterStateChange` event (adapter, old_state, new_state, reason)
-- [ ] 1.7 Add comprehensive docstrings explaining when each event fires
-- [ ] 1.8 Create `PipelineResult` dataclass for backwards compatibility
+- [x] 1.1 Define `PipelineEvent` base class with common fields (timestamp, pipeline_id)
+- [x] 1.2 Define `DocumentStarted` event (doc_id, adapter, parameters)
+- [x] 1.3 Define `DocumentCompleted` event (document, duration, metadata)
+- [x] 1.4 Define `DocumentFailed` event (doc_id, error, retry_count, is_retryable)
+- [x] 1.5 Define `BatchProgress` event (completed_count, failed_count, remaining, eta)
+- [x] 1.6 Define `AdapterStateChange` event (adapter, old_state, new_state, reason)
+- [x] 1.7 Add comprehensive docstrings explaining when each event fires
+- [x] 1.8 Create `PipelineResult` dataclass for backwards compatibility
 
 ## 2. Implement Streaming Core
 
-- [ ] 2.1 Create `src/Medical_KG/ingestion/events.py` module for event classes
-- [ ] 2.2 Add `IngestionPipeline.stream_events()` async iterator method
-- [ ] 2.3 Refactor adapter invocation to emit `DocumentStarted` before processing
-- [ ] 2.4 Emit `DocumentCompleted` after successful parse + validate
-- [ ] 2.5 Emit `DocumentFailed` on exceptions with retry context
-- [ ] 2.6 Emit `BatchProgress` every N documents (configurable, default 100)
-- [ ] 2.7 Emit `AdapterStateChange` for adapter lifecycle transitions
-- [ ] 2.8 Add comprehensive type hints for all event types
+- [x] 2.1 Create `src/Medical_KG/ingestion/events.py` module for event classes
+- [x] 2.2 Add `IngestionPipeline.stream_events()` async iterator method
+- [x] 2.3 Refactor adapter invocation to emit `DocumentStarted` before processing
+- [x] 2.4 Emit `DocumentCompleted` after successful parse + validate
+- [x] 2.5 Emit `DocumentFailed` on exceptions with retry context
+- [x] 2.6 Emit `BatchProgress` every N documents (configurable, default 100)
+- [x] 2.7 Emit `AdapterStateChange` for adapter lifecycle transitions
+- [x] 2.8 Add comprehensive type hints for all event types
 
 ## 3. Update iter_results() for Backwards Compatibility
 
-- [ ] 3.1 Reimplement `iter_results()` as filter over `stream_events()`
-- [ ] 3.2 Extract `document` field from `DocumentCompleted` events
-- [ ] 3.3 Skip other event types silently
-- [ ] 3.4 Maintain identical behavior for existing callers
-- [ ] 3.5 Add deprecation notice (6-month migration to `stream_events()`)
-- [ ] 3.6 Update docstring to recommend `stream_events()` for new code
+- [x] 3.1 Reimplement `iter_results()` as filter over `stream_events()`
+- [x] 3.2 Extract `document` field from `DocumentCompleted` events
+- [x] 3.3 Skip other event types silently
+- [x] 3.4 Maintain identical behavior for existing callers
+- [x] 3.5 Add deprecation notice (6-month migration to `stream_events()`)
+- [x] 3.6 Update docstring to recommend `stream_events()` for new code
 
 ## 4. Create Convenience run_async() Wrapper
 
-- [ ] 4.1 Implement `run_async()` as eager consumer of `iter_results()`
-- [ ] 4.2 Collect all documents into list (document high memory usage)
-- [ ] 4.3 Collect all errors from `DocumentFailed` events
-- [ ] 4.4 Calculate aggregate statistics (success/fail counts, duration)
-- [ ] 4.5 Return `PipelineResult` with documents, errors, stats
-- [ ] 4.6 Add performance warning in docstring about memory usage
-- [ ] 4.7 Recommend `stream_events()` for large batches
+- [x] 4.1 Implement `run_async()` as eager consumer of `iter_results()`
+- [x] 4.2 Collect all documents into list (document high memory usage)
+- [x] 4.3 Collect all errors from `DocumentFailed` events
+- [x] 4.4 Calculate aggregate statistics (success/fail counts, duration)
+- [x] 4.5 Return `PipelineResult` with documents, errors, stats
+- [x] 4.6 Add performance warning in docstring about memory usage
+- [x] 4.7 Recommend `stream_events()` for large batches
 
 ## 5. Add Legacy Compatibility Layer
 
-- [ ] 5.1 Create `run_async_legacy()` with old signature
-- [ ] 5.2 Emit deprecation warning when called
-- [ ] 5.3 Delegate to new `run_async()` implementation
-- [ ] 5.4 Document 6-month deprecation timeline
-- [ ] 5.5 Add environment variable to silence warnings (for CI)
-- [ ] 5.6 Track usage metrics for migration monitoring
+- [x] 5.1 Create `run_async_legacy()` with old signature
+- [x] 5.2 Emit deprecation warning when called
+- [x] 5.3 Delegate to new `run_async()` implementation
+- [x] 5.4 Document 6-month deprecation timeline
+- [x] 5.5 Add environment variable to silence warnings (for CI)
+- [x] 5.6 Track usage metrics for migration monitoring
 
 ## 6. Update CLI to Use Streaming
 
@@ -72,12 +72,12 @@
 
 ## 8. Implement Backpressure Mechanism
 
-- [ ] 8.1 Add configurable buffer size to `stream_events()` (default 100)
-- [ ] 8.2 Block adapter fetching when buffer is full
-- [ ] 8.3 Resume fetching when consumer drains buffer
-- [ ] 8.4 Add metrics for backpressure events (queue depth, wait time)
-- [ ] 8.5 Document backpressure behavior in pipeline guide
-- [ ] 8.6 Test with slow consumers (e.g., rate-limited API)
+- [x] 8.1 Add configurable buffer size to `stream_events()` (default 100)
+- [x] 8.2 Block adapter fetching when buffer is full
+- [x] 8.3 Resume fetching when consumer drains buffer
+- [x] 8.4 Add metrics for backpressure events (queue depth, wait time)
+- [x] 8.5 Document backpressure behavior in pipeline guide
+- [x] 8.6 Test with slow consumers (e.g., rate-limited API)
 
 ## 9. Add Checkpointing Support
 
@@ -90,12 +90,12 @@
 
 ## 10. Add Event Filtering and Transformation
 
-- [ ] 10.1 Add `event_filter` callback parameter to `stream_events()`
-- [ ] 10.2 Allow filtering by event type (e.g., errors only)
-- [ ] 10.3 Add `event_transformer` for custom event enrichment
-- [ ] 10.4 Provide built-in filters (errors_only, progress_only)
-- [ ] 10.5 Document filter composition patterns
-- [ ] 10.6 Add examples for common filtering scenarios
+- [x] 10.1 Add `event_filter` callback parameter to `stream_events()`
+- [x] 10.2 Allow filtering by event type (e.g., errors only)
+- [x] 10.3 Add `event_transformer` for custom event enrichment
+- [x] 10.4 Provide built-in filters (errors_only, progress_only)
+- [x] 10.5 Document filter composition patterns
+- [x] 10.6 Add examples for common filtering scenarios
 
 ## 11. Update Adapter Base Classes
 
@@ -108,15 +108,15 @@
 
 ## 12. Add Comprehensive Tests
 
-- [ ] 12.1 Test `stream_events()` with mock adapter
-- [ ] 12.2 Test all event types are emitted correctly
-- [ ] 12.3 Test event ordering (Started → Completed/Failed)
-- [ ] 12.4 Test backpressure with slow consumer
+- [x] 12.1 Test `stream_events()` with mock adapter
+- [x] 12.2 Test all event types are emitted correctly
+- [x] 12.3 Test event ordering (Started → Completed/Failed)
+- [x] 12.4 Test backpressure with slow consumer
 - [ ] 12.5 Test checkpoint boundaries and resume
-- [ ] 12.6 Test filtering and transformation
-- [ ] 12.7 Test backwards compatibility via `iter_results()`
-- [ ] 12.8 Test `run_async()` aggregation logic
-- [ ] 12.9 Test error handling and retry events
+- [x] 12.6 Test filtering and transformation
+- [x] 12.7 Test backwards compatibility via `iter_results()`
+- [x] 12.8 Test `run_async()` aggregation logic
+- [x] 12.9 Test error handling and retry events
 - [ ] 12.10 Test concurrent pipeline execution
 - [ ] 12.11 Integration test with real adapters
 - [ ] 12.12 Performance test: 100k documents with streaming vs eager

--- a/src/Medical_KG/ingestion/adapters/base.py
+++ b/src/Medical_KG/ingestion/adapters/base.py
@@ -5,10 +5,10 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, TypeVar
 
+from Medical_KG.ingestion.events import PipelineEvent
 from Medical_KG.ingestion.ledger import IngestionLedger
 from Medical_KG.ingestion.models import Document, IngestionResult
 from Medical_KG.ingestion.utils import generate_doc_id
-from Medical_KG.ingestion.events import PipelineEvent
 
 
 @dataclass(slots=True)

--- a/src/Medical_KG/ingestion/events.py
+++ b/src/Medical_KG/ingestion/events.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import dataclasses
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+from datetime import datetime
+from typing import Any, Callable, Mapping, MutableMapping
 
 from Medical_KG.ingestion.models import Document
 
 
 @dataclass(slots=True)
 class PipelineEvent:
-    """Base event emitted during pipeline execution."""
+    """Base event emitted during pipeline execution.
+
+    Every concrete event produced by :class:`IngestionPipeline` extends this
+    dataclass to ensure consistent typing and serialisation semantics.
+    """
 
     timestamp: float
     pipeline_id: str
@@ -21,16 +25,26 @@ class PipelineEvent:
 
 @dataclass(slots=True)
 class DocumentStarted(PipelineEvent):
-    """Indicates that processing for a document has begun."""
+    """Indicates that adapter processing for a document has begun.
 
-    doc_id: str | None
+    The pipeline emits this event immediately before handing a document off to
+    downstream consumers, ensuring lifecycle events are observable even when
+    the consumer processes slowly or fails mid-stream.
+    """
+
+    doc_id: str
     adapter: str
     parameters: Mapping[str, Any]
 
 
 @dataclass(slots=True)
 class DocumentCompleted(PipelineEvent):
-    """Represents a successfully processed document."""
+    """Represents a successfully processed document.
+
+    The attached :class:`~Medical_KG.ingestion.models.Document` contains the
+    final parsed payload, while ``adapter_metadata`` carries any adapter
+    specific information (HTTP timings, pagination cursors, etc.).
+    """
 
     document: Document
     duration: float
@@ -39,7 +53,11 @@ class DocumentCompleted(PipelineEvent):
 
 @dataclass(slots=True)
 class DocumentFailed(PipelineEvent):
-    """Represents a document processing failure."""
+    """Represents a document processing failure.
+
+    The failure event preserves retry context so orchestrators can decide
+    whether to requeue the document or surface the error to operators.
+    """
 
     doc_id: str | None
     error: str
@@ -51,17 +69,30 @@ class DocumentFailed(PipelineEvent):
 
 @dataclass(slots=True)
 class BatchProgress(PipelineEvent):
-    """Progress update emitted periodically during processing."""
+    """Progress update emitted periodically during processing.
+
+    Progress events expose throughput metrics, remaining counts (when known),
+    and backpressure measurements derived from the bounded event queue.
+    """
 
     completed_count: int
     failed_count: int
+    in_flight_count: int
+    queue_depth: int
+    buffer_size: int
     remaining: int | None
     eta_seconds: float | None
+    backpressure_wait_seconds: float
+    backpressure_wait_count: int
 
 
 @dataclass(slots=True)
 class AdapterStateChange(PipelineEvent):
-    """Signals that an adapter has transitioned between lifecycle states."""
+    """Signals that an adapter has transitioned between lifecycle states.
+
+    These events allow consumers to monitor adapter lifecycle, including
+    transitions to failure states with accompanying reasons.
+    """
 
     adapter: str
     old_state: str
@@ -71,7 +102,11 @@ class AdapterStateChange(PipelineEvent):
 
 @dataclass(slots=True)
 class PipelineResult:
-    """Aggregated summary of a pipeline execution."""
+    """Aggregated summary of a pipeline execution.
+
+    Instances of this dataclass are returned by the eager convenience wrapper
+    :meth:`IngestionPipeline.run_async` for compatibility with legacy code.
+    """
 
     source: str
     documents: list[Document]


### PR DESCRIPTION
## Summary
- introduce a documented PipelineEvent hierarchy with richer progress metrics and compatibility result objects
- refactor IngestionPipeline streaming to expose filters, backpressure metrics, and adapter lifecycle events while updating docs and tasks
- expand ingestion pipeline tests to cover event ordering, filtering, and backpressure scenarios

## Testing
- python -m pytest tests/ingestion/test_pipeline.py
- python -m ruff check src/Medical_KG/ingestion


------
https://chatgpt.com/codex/tasks/task_e_68e0bfa3a5c4832fa053b96012da8eea